### PR TITLE
Comparable Expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PSQL query function builders for [FluentKit](https://github.com/vapor/fluent-kit
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/hiimtmac/PSQLKit.git", from: "0.8.0")
+    .package(url: "https://github.com/hiimtmac/PSQLKit.git", from: "0.9.0")
 ],
 ```
 

--- a/Sources/PSQLKit/Arithmetic.swift
+++ b/Sources/PSQLKit/Arithmetic.swift
@@ -19,7 +19,11 @@ public struct ArithmeticOperator: SQLExpression {
     }
 }
 
-public struct ArithmeticExpression<T, U> where T: TypeEquatable, U: TypeEquatable, T.CompareType == U.CompareType {
+public struct ArithmeticExpression<T, U> where
+    T: TypeEquatable,
+    U: TypeEquatable,
+    T.CompareType == U.CompareType
+{
     let lhs: T
     let `operator`: ArithmeticOperator
     let rhs: U
@@ -35,7 +39,10 @@ extension ArithmeticExpression: TypeEquatable {
     public typealias CompareType = T.CompareType
 }
 
-extension ArithmeticExpression: SelectSQLExpression where T: SelectSQLExpression, U: SelectSQLExpression, T.CompareType: PSQLExpression {
+extension ArithmeticExpression: SelectSQLExpression where
+    T: SelectSQLExpression,
+    U: SelectSQLExpression
+{
     public var selectSqlExpression: some SQLExpression {
         _Select(lhs: lhs, operator: `operator`, rhs: rhs)
     }
@@ -65,7 +72,10 @@ extension ArithmeticExpression {
     }
 }
 
-extension ArithmeticExpression: CompareSQLExpression where T: CompareSQLExpression, U: CompareSQLExpression {
+extension ArithmeticExpression: CompareSQLExpression where
+    T: CompareSQLExpression,
+    U: CompareSQLExpression
+{
     public var compareSqlExpression: some SQLExpression {
         _Compare(lhs: lhs, operator: `operator`, rhs: rhs)
     }
@@ -87,19 +97,28 @@ extension ArithmeticExpression: CompareSQLExpression where T: CompareSQLExpressi
     }
 }
 
-extension ArithmeticExpression: WhereSQLExpression where T: CompareSQLExpression, U: CompareSQLExpression {
+extension ArithmeticExpression: WhereSQLExpression where
+    T: CompareSQLExpression,
+    U: CompareSQLExpression
+{
     public var whereSqlExpression: some SQLExpression {
         _Compare(lhs: lhs, operator: `operator`, rhs: rhs)
     }
 }
 
-extension ArithmeticExpression: HavingSQLExpression where T: CompareSQLExpression, U: CompareSQLExpression {
+extension ArithmeticExpression: HavingSQLExpression where
+    T: CompareSQLExpression,
+    U: CompareSQLExpression
+{
     public var havingSqlExpression: some SQLExpression {
         _Compare(lhs: lhs, operator: `operator`, rhs: rhs)
     }
 }
 
-extension ArithmeticExpression: JoinSQLExpression where T: CompareSQLExpression, U: CompareSQLExpression {
+extension ArithmeticExpression: JoinSQLExpression where
+    T: CompareSQLExpression,
+    U: CompareSQLExpression
+{
     public var joinSqlExpression: some SQLExpression {
         _Compare(lhs: lhs, operator: `operator`, rhs: rhs)
     }

--- a/Sources/PSQLKit/Comparisons.swift
+++ b/Sources/PSQLKit/Comparisons.swift
@@ -32,7 +32,10 @@ public struct CompareOperator: SQLExpression {
     }
 }
 
-public struct CompareExpression<T, U> where T: CompareSQLExpression, U: CompareSQLExpression {
+public struct CompareExpression<T, U> where
+    T: CompareSQLExpression,
+    U: CompareSQLExpression
+{
     let lhs: T
     let `operator`: CompareOperator
     let rhs: U
@@ -79,59 +82,6 @@ extension CompareExpression: HavingSQLExpression {
 }
 
 extension CompareExpression: JoinSQLExpression {
-    public var joinSqlExpression: some SQLExpression {
-        _Compare(lhs: lhs, operator: `operator`, rhs: rhs)
-    }
-}
-
-public struct AnyCompareExpression {
-    let lhs: SQLExpression
-    let `operator`: CompareOperator
-    let rhs: SQLExpression
-    
-    public init<T, U>(lhs: T, operator: CompareOperator, rhs: U) where T: CompareSQLExpression, U: CompareSQLExpression
-    {
-        self.lhs = lhs.compareSqlExpression
-        self.operator = `operator`
-        self.rhs = rhs.compareSqlExpression
-    }
-}
-
-extension AnyCompareExpression: CompareSQLExpression {
-    public var compareSqlExpression: some SQLExpression {
-        _Compare(lhs: lhs, operator: `operator`, rhs: rhs)
-    }
-    
-    private struct _Compare: SQLExpression {
-        let lhs: SQLExpression
-        let `operator`: CompareOperator
-        let rhs: SQLExpression
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("(")
-            lhs.serialize(to: &serializer)
-            serializer.writeSpace()
-            `operator`.serialize(to: &serializer)
-            serializer.writeSpace()
-            rhs.serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension AnyCompareExpression: WhereSQLExpression {
-    public var whereSqlExpression: some SQLExpression {
-        _Compare(lhs: lhs, operator: `operator`, rhs: rhs)
-    }
-}
-
-extension AnyCompareExpression: HavingSQLExpression {
-    public var havingSqlExpression: some SQLExpression {
-        _Compare(lhs: lhs, operator: `operator`, rhs: rhs)
-    }
-}
-
-extension AnyCompareExpression: JoinSQLExpression {
     public var joinSqlExpression: some SQLExpression {
         _Compare(lhs: lhs, operator: `operator`, rhs: rhs)
     }

--- a/Sources/PSQLKit/Expressions/AverageExpression.swift
+++ b/Sources/PSQLKit/Expressions/AverageExpression.swift
@@ -9,7 +9,9 @@ public struct AverageExpression<Content>: AggregateExpression {
     }
 }
 
-extension AverageExpression: SelectSQLExpression where Content: SelectSQLExpression {
+extension AverageExpression: SelectSQLExpression where
+    Content: SelectSQLExpression
+{
     public var selectSqlExpression: some SQLExpression {
         _Select(content: content)
     }
@@ -26,7 +28,9 @@ extension AverageExpression: SelectSQLExpression where Content: SelectSQLExpress
     }
 }
 
-extension AverageExpression: CompareSQLExpression where Content: CompareSQLExpression {
+extension AverageExpression: CompareSQLExpression where
+    Content: CompareSQLExpression
+{
     public var compareSqlExpression: some SQLExpression {
         _Compare(content: content)
     }

--- a/Sources/PSQLKit/Expressions/CoalesceExpression.swift
+++ b/Sources/PSQLKit/Expressions/CoalesceExpression.swift
@@ -2,9 +2,9 @@ import Foundation
 import SQLKit
 
 // MARK: CoalesceExpression
-public struct CoalesceExpression<T0, T1>: SQLExpression where
-    T0: SelectSQLExpression & TypeEquatable,
-    T1: SelectSQLExpression & TypeEquatable,
+public struct CoalesceExpression<T0, T1> where
+    T0: TypeEquatable,
+    T1: TypeEquatable,
     T0.CompareType == T1.CompareType
 {
     let t0: T0
@@ -14,24 +14,58 @@ public struct CoalesceExpression<T0, T1>: SQLExpression where
         self.t0 = t0
         self.t1 = t1
     }
-    
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("COALESCE")
-        serializer.write("(")
-        SQLList([
-            t0.selectSqlExpression,
-            t1.selectSqlExpression
-        ]).serialize(to: &serializer)
-        serializer.write(")")
-    }
 }
 
 extension CoalesceExpression: TypeEquatable {
     public typealias CompareType = T0.CompareType
 }
 
-extension CoalesceExpression: SelectSQLExpression {
-    public var selectSqlExpression: some SQLExpression { self }
+extension CoalesceExpression: SelectSQLExpression where
+    T0: SelectSQLExpression,
+    T1: SelectSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(t0: t0, t1: t1)
+    }
+    
+    private struct _Select: SQLExpression {
+        let t0: T0
+        let t1: T1
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("COALESCE")
+            serializer.write("(")
+            SQLList([
+                t0.selectSqlExpression,
+                t1.selectSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
+}
+
+extension CoalesceExpression: CompareSQLExpression where
+    T0: CompareSQLExpression,
+    T1: CompareSQLExpression
+{
+    public var compareSqlExpression: some SQLExpression {
+        _Compare(t0: t0, t1: t1)
+    }
+    
+    private struct _Compare: SQLExpression {
+        let t0: T0
+        let t1: T1
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("COALESCE")
+            serializer.write("(")
+            SQLList([
+                t0.compareSqlExpression,
+                t1.compareSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
 extension CoalesceExpression {
@@ -41,10 +75,10 @@ extension CoalesceExpression {
 }
 
 // MARK: CoalesceExpression3
-public struct CoalesceExpression3<T0, T1, T2>: SQLExpression where
-    T0: SelectSQLExpression & TypeEquatable,
-    T1: SelectSQLExpression & TypeEquatable,
-    T2: SelectSQLExpression & TypeEquatable,
+public struct CoalesceExpression3<T0, T1, T2> where
+    T0: TypeEquatable,
+    T1: TypeEquatable,
+    T2: TypeEquatable,
     T0.CompareType == T1.CompareType,
     T1.CompareType == T2.CompareType
 {
@@ -57,25 +91,64 @@ public struct CoalesceExpression3<T0, T1, T2>: SQLExpression where
         self.t1 = t1
         self.t2 = t2
     }
-    
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("COALESCE")
-        serializer.write("(")
-        SQLList([
-            t0.selectSqlExpression,
-            t1.selectSqlExpression,
-            t2.selectSqlExpression
-        ]).serialize(to: &serializer)
-        serializer.write(")")
-    }
 }
 
 extension CoalesceExpression3: TypeEquatable {
     public typealias CompareType = T0.CompareType
 }
 
-extension CoalesceExpression3: SelectSQLExpression {
-    public var selectSqlExpression: some SQLExpression { self }
+extension CoalesceExpression3: SelectSQLExpression where
+    T0: SelectSQLExpression,
+    T1: SelectSQLExpression,
+    T2: SelectSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(t0: t0, t1: t1, t2: t2)
+    }
+    
+    private struct _Select: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("COALESCE")
+            serializer.write("(")
+            SQLList([
+                t0.selectSqlExpression,
+                t1.selectSqlExpression,
+                t2.selectSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
+}
+
+extension CoalesceExpression3: CompareSQLExpression where
+    T0: CompareSQLExpression,
+    T1: CompareSQLExpression,
+    T2: CompareSQLExpression
+{
+    public var compareSqlExpression: some SQLExpression {
+        _Compare(t0: t0, t1: t1, t2: t2)
+    }
+    
+    private struct _Compare: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("COALESCE")
+            serializer.write("(")
+            SQLList([
+                t0.compareSqlExpression,
+                t1.compareSqlExpression,
+                t2.compareSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
 extension CoalesceExpression3 {
@@ -85,11 +158,11 @@ extension CoalesceExpression3 {
 }
 
 // MARK: CoalesceExpression4
-public struct CoalesceExpression4<T0, T1, T2, T3>: SQLExpression where
-    T0: SelectSQLExpression & TypeEquatable,
-    T1: SelectSQLExpression & TypeEquatable,
-    T2: SelectSQLExpression & TypeEquatable,
-    T3: SelectSQLExpression & TypeEquatable,
+public struct CoalesceExpression4<T0, T1, T2, T3> where
+    T0: TypeEquatable,
+    T1: TypeEquatable,
+    T2: TypeEquatable,
+    T3: TypeEquatable,
     T0.CompareType == T1.CompareType,
     T1.CompareType == T2.CompareType,
     T2.CompareType == T3.CompareType
@@ -105,26 +178,70 @@ public struct CoalesceExpression4<T0, T1, T2, T3>: SQLExpression where
         self.t2 = t2
         self.t3 = t3
     }
-    
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("COALESCE")
-        serializer.write("(")
-        SQLList([
-            t0.selectSqlExpression,
-            t1.selectSqlExpression,
-            t2.selectSqlExpression,
-            t3.selectSqlExpression
-        ]).serialize(to: &serializer)
-        serializer.write(")")
-    }
 }
 
 extension CoalesceExpression4: TypeEquatable {
     public typealias CompareType = T0.CompareType
 }
 
-extension CoalesceExpression4: SelectSQLExpression {
-    public var selectSqlExpression: some SQLExpression { self }
+extension CoalesceExpression4: SelectSQLExpression where
+    T0: SelectSQLExpression,
+    T1: SelectSQLExpression,
+    T2: SelectSQLExpression,
+    T3: SelectSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(t0: t0, t1: t1, t2: t2, t3: t3)
+    }
+    
+    private struct _Select: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("COALESCE")
+            serializer.write("(")
+            SQLList([
+                t0.selectSqlExpression,
+                t1.selectSqlExpression,
+                t2.selectSqlExpression,
+                t3.selectSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
+}
+
+extension CoalesceExpression4: CompareSQLExpression where
+    T0: CompareSQLExpression,
+    T1: CompareSQLExpression,
+    T2: CompareSQLExpression,
+    T3: CompareSQLExpression
+{
+    public var compareSqlExpression: some SQLExpression {
+        _Compare(t0: t0, t1: t1, t2: t2, t3: t3)
+    }
+    
+    private struct _Compare: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("COALESCE")
+            serializer.write("(")
+            SQLList([
+                t0.compareSqlExpression,
+                t1.compareSqlExpression,
+                t2.compareSqlExpression,
+                t3.compareSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
 extension CoalesceExpression4 {
@@ -134,12 +251,12 @@ extension CoalesceExpression4 {
 }
 
 // MARK: CoalesceExpression5
-public struct CoalesceExpression5<T0, T1, T2, T3, T4>: SQLExpression where
-    T0: SelectSQLExpression & TypeEquatable,
-    T1: SelectSQLExpression & TypeEquatable,
-    T2: SelectSQLExpression & TypeEquatable,
-    T3: SelectSQLExpression & TypeEquatable,
-    T4: SelectSQLExpression & TypeEquatable,
+public struct CoalesceExpression5<T0, T1, T2, T3, T4> where
+    T0: TypeEquatable,
+    T1: TypeEquatable,
+    T2: TypeEquatable,
+    T3: TypeEquatable,
+    T4: TypeEquatable,
     T0.CompareType == T1.CompareType,
     T1.CompareType == T2.CompareType,
     T2.CompareType == T3.CompareType,
@@ -158,27 +275,76 @@ public struct CoalesceExpression5<T0, T1, T2, T3, T4>: SQLExpression where
         self.t3 = t3
         self.t4 = t4
     }
-    
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("COALESCE")
-        serializer.write("(")
-        SQLList([
-            t0.selectSqlExpression,
-            t1.selectSqlExpression,
-            t2.selectSqlExpression,
-            t3.selectSqlExpression,
-            t4.selectSqlExpression
-        ]).serialize(to: &serializer)
-        serializer.write(")")
-    }
 }
 
 extension CoalesceExpression5: TypeEquatable {
     public typealias CompareType = T0.CompareType
 }
 
-extension CoalesceExpression5: SelectSQLExpression {
-    public var selectSqlExpression: some SQLExpression { self }
+extension CoalesceExpression5: SelectSQLExpression where
+    T0: SelectSQLExpression,
+    T1: SelectSQLExpression,
+    T2: SelectSQLExpression,
+    T3: SelectSQLExpression,
+    T4: SelectSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
+    }
+    
+    private struct _Select: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        let t4: T4
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("COALESCE")
+            serializer.write("(")
+            SQLList([
+                t0.selectSqlExpression,
+                t1.selectSqlExpression,
+                t2.selectSqlExpression,
+                t3.selectSqlExpression,
+                t4.selectSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
+}
+
+extension CoalesceExpression5: CompareSQLExpression where
+    T0: CompareSQLExpression,
+    T1: CompareSQLExpression,
+    T2: CompareSQLExpression,
+    T3: CompareSQLExpression,
+    T4: CompareSQLExpression
+{
+    public var compareSqlExpression: some SQLExpression {
+        _Compare(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
+    }
+    
+    private struct _Compare: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        let t4: T4
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("COALESCE")
+            serializer.write("(")
+            SQLList([
+                t0.compareSqlExpression,
+                t1.compareSqlExpression,
+                t2.compareSqlExpression,
+                t3.compareSqlExpression,
+                t4.compareSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
 extension CoalesceExpression5 {

--- a/Sources/PSQLKit/Expressions/ConcatExpression.swift
+++ b/Sources/PSQLKit/Expressions/ConcatExpression.swift
@@ -2,9 +2,10 @@ import Foundation
 import SQLKit
 
 // MARK: ConcatExpression
-public struct ConcatExpression<T0, T1>: SQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression
+public struct ConcatExpression<T0, T1> where
+    T0: TypeEquatable,
+    T1: TypeEquatable,
+    T0.CompareType == T1.CompareType
 {
     let t0: T0
     let t1: T1
@@ -16,24 +17,82 @@ public struct ConcatExpression<T0, T1>: SQLExpression where
         self.t0 = t0
         self.t1 = t1
     }
+}
+
+extension ConcatExpression: TypeEquatable {
+    public typealias CompareType = T0.CompareType
+}
+
+extension ConcatExpression: SelectSQLExpression where
+    T0: SelectSQLExpression,
+    T1: SelectSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(t0: t0, t1: t1)
+    }
     
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("CONCAT")
-        serializer.write("(")
-        SQLList([
-            t0.selectSqlExpression,
-            t1.selectSqlExpression
-        ]).serialize(to: &serializer)
-        serializer.write(")")
+    private struct _Select: SQLExpression {
+        let t0: T0
+        let t1: T1
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.selectSqlExpression,
+                t1.selectSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
     }
 }
 
-extension ConcatExpression: SelectSQLExpression {
-    public var selectSqlExpression: some SQLExpression { self }
+extension ConcatExpression: GroupBySQLExpression where
+    T0: GroupBySQLExpression,
+    T1: GroupBySQLExpression
+{
+    public var groupBySqlExpression: some SQLExpression {
+        _GroupBy(t0: t0, t1: t1)
+    }
+    
+    private struct _GroupBy: SQLExpression {
+        let t0: T0
+        let t1: T1
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.groupBySqlExpression,
+                t1.groupBySqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
-extension ConcatExpression: GroupBySQLExpression {
-    public var groupBySqlExpression: some SQLExpression { self }
+extension ConcatExpression: CompareSQLExpression where
+    T0: CompareSQLExpression,
+    T1: CompareSQLExpression
+{
+    public var compareSqlExpression: some SQLExpression {
+        _Compare(t0: t0, t1: t1)
+    }
+    
+    private struct _Compare: SQLExpression {
+        let t0: T0
+        let t1: T1
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.compareSqlExpression,
+                t1.compareSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
 extension ConcatExpression {
@@ -43,10 +102,12 @@ extension ConcatExpression {
 }
 
 // MARK: ConcatExpression3
-public struct ConcatExpression3<T0, T1, T2>: SQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression,
-    T2: SelectSQLExpression
+public struct ConcatExpression3<T0, T1, T2> where
+    T0: TypeEquatable,
+    T1: TypeEquatable,
+    T2: TypeEquatable,
+    T0.CompareType == T1.CompareType,
+    T1.CompareType == T2.CompareType
 {
     let t0: T0
     let t1: T1
@@ -61,25 +122,91 @@ public struct ConcatExpression3<T0, T1, T2>: SQLExpression where
         self.t1 = t1
         self.t2 = t2
     }
+}
+
+extension ConcatExpression3: TypeEquatable {
+    public typealias CompareType = T0.CompareType
+}
+
+extension ConcatExpression3: SelectSQLExpression where
+    T0: SelectSQLExpression,
+    T1: SelectSQLExpression,
+    T2: SelectSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(t0: t0, t1: t1, t2: t2)
+    }
     
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("CONCAT")
-        serializer.write("(")
-        SQLList([
-            t0.selectSqlExpression,
-            t1.selectSqlExpression,
-            t2.selectSqlExpression
-        ]).serialize(to: &serializer)
-        serializer.write(")")
+    private struct _Select: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.selectSqlExpression,
+                t1.selectSqlExpression,
+                t2.selectSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
     }
 }
 
-extension ConcatExpression3: SelectSQLExpression {
-    public var selectSqlExpression: some SQLExpression { self }
+extension ConcatExpression3: GroupBySQLExpression where
+    T0: GroupBySQLExpression,
+    T1: GroupBySQLExpression,
+    T2: GroupBySQLExpression
+{
+    public var groupBySqlExpression: some SQLExpression {
+        _GroupBy(t0: t0, t1: t1, t2: t2)
+    }
+    
+    private struct _GroupBy: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.groupBySqlExpression,
+                t1.groupBySqlExpression,
+                t2.groupBySqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
-extension ConcatExpression3: GroupBySQLExpression {
-    public var groupBySqlExpression: some SQLExpression { self }
+extension ConcatExpression3: CompareSQLExpression where
+    T0: CompareSQLExpression,
+    T1: CompareSQLExpression,
+    T2: CompareSQLExpression
+{
+    public var compareSqlExpression: some SQLExpression {
+        _Compare(t0: t0, t1: t1, t2: t2)
+    }
+    
+    private struct _Compare: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.compareSqlExpression,
+                t1.compareSqlExpression,
+                t2.compareSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
 extension ConcatExpression3 {
@@ -89,11 +216,14 @@ extension ConcatExpression3 {
 }
 
 // MARK: ConcatExpression4
-public struct ConcatExpression4<T0, T1, T2, T3>: SQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression,
-    T2: SelectSQLExpression,
-    T3: SelectSQLExpression
+public struct ConcatExpression4<T0, T1, T2, T3> where
+    T0: TypeEquatable,
+    T1: TypeEquatable,
+    T2: TypeEquatable,
+    T3: TypeEquatable,
+    T0.CompareType == T1.CompareType,
+    T1.CompareType == T2.CompareType,
+    T2.CompareType == T3.CompareType
 {
     let t0: T0
     let t1: T1
@@ -111,26 +241,100 @@ public struct ConcatExpression4<T0, T1, T2, T3>: SQLExpression where
         self.t2 = t2
         self.t3 = t3
     }
+}
+
+extension ConcatExpression4: TypeEquatable {
+    public typealias CompareType = T0.CompareType
+}
+
+extension ConcatExpression4: SelectSQLExpression where
+    T0: SelectSQLExpression,
+    T1: SelectSQLExpression,
+    T2: SelectSQLExpression,
+    T3: SelectSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(t0: t0, t1: t1, t2: t2, t3: t3)
+    }
     
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("CONCAT")
-        serializer.write("(")
-        SQLList([
-            t0.selectSqlExpression,
-            t1.selectSqlExpression,
-            t2.selectSqlExpression,
-            t3.selectSqlExpression
-        ]).serialize(to: &serializer)
-        serializer.write(")")
+    private struct _Select: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.selectSqlExpression,
+                t1.selectSqlExpression,
+                t2.selectSqlExpression,
+                t3.selectSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
     }
 }
 
-extension ConcatExpression4: SelectSQLExpression {
-    public var selectSqlExpression: some SQLExpression { self }
+extension ConcatExpression4: GroupBySQLExpression where
+    T0: GroupBySQLExpression,
+    T1: GroupBySQLExpression,
+    T2: GroupBySQLExpression,
+    T3: GroupBySQLExpression
+{
+    public var groupBySqlExpression: some SQLExpression {
+        _GroupBy(t0: t0, t1: t1, t2: t2, t3: t3)
+    }
+    
+    private struct _GroupBy: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.groupBySqlExpression,
+                t1.groupBySqlExpression,
+                t2.groupBySqlExpression,
+                t3.groupBySqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
-extension ConcatExpression4: GroupBySQLExpression {
-    public var groupBySqlExpression: some SQLExpression { self }
+extension ConcatExpression4: CompareSQLExpression where
+    T0: CompareSQLExpression,
+    T1: CompareSQLExpression,
+    T2: CompareSQLExpression,
+    T3: CompareSQLExpression
+{
+    public var compareSqlExpression: some SQLExpression {
+        _Compare(t0: t0, t1: t1, t2: t2, t3: t3)
+    }
+    
+    private struct _Compare: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.compareSqlExpression,
+                t1.compareSqlExpression,
+                t2.compareSqlExpression,
+                t3.compareSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
 extension ConcatExpression4 {
@@ -140,12 +344,16 @@ extension ConcatExpression4 {
 }
 
 // MARK: ConcatExpression5
-public struct ConcatExpression5<T0, T1, T2, T3, T4>: SQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression,
-    T2: SelectSQLExpression,
-    T3: SelectSQLExpression,
-    T4: SelectSQLExpression
+public struct ConcatExpression5<T0, T1, T2, T3, T4> where
+    T0: TypeEquatable,
+    T1: TypeEquatable,
+    T2: TypeEquatable,
+    T3: TypeEquatable,
+    T4: TypeEquatable,
+    T0.CompareType == T1.CompareType,
+    T1.CompareType == T2.CompareType,
+    T2.CompareType == T3.CompareType,
+    T3.CompareType == T4.CompareType
 {
     let t0: T0
     let t1: T1
@@ -166,27 +374,109 @@ public struct ConcatExpression5<T0, T1, T2, T3, T4>: SQLExpression where
         self.t3 = t3
         self.t4 = t4
     }
+}
+
+extension ConcatExpression5: TypeEquatable {
+    public typealias CompareType = T0.CompareType
+}
+
+extension ConcatExpression5: SelectSQLExpression where
+    T0: SelectSQLExpression,
+    T1: SelectSQLExpression,
+    T2: SelectSQLExpression,
+    T3: SelectSQLExpression,
+    T4: SelectSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
+    }
     
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("CONCAT")
-        serializer.write("(")
-        SQLList([
-            t0.selectSqlExpression,
-            t1.selectSqlExpression,
-            t2.selectSqlExpression,
-            t3.selectSqlExpression,
-            t4.selectSqlExpression
-        ]).serialize(to: &serializer)
-        serializer.write(")")
+    private struct _Select: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        let t4: T4
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.selectSqlExpression,
+                t1.selectSqlExpression,
+                t2.selectSqlExpression,
+                t3.selectSqlExpression,
+                t4.selectSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
     }
 }
 
-extension ConcatExpression5: SelectSQLExpression {
-    public var selectSqlExpression: some SQLExpression { self }
+extension ConcatExpression5: GroupBySQLExpression where
+    T0: GroupBySQLExpression,
+    T1: GroupBySQLExpression,
+    T2: GroupBySQLExpression,
+    T3: GroupBySQLExpression,
+    T4: GroupBySQLExpression
+{
+    public var groupBySqlExpression: some SQLExpression {
+        _GroupBy(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
+    }
+    
+    private struct _GroupBy: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        let t4: T4
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.groupBySqlExpression,
+                t1.groupBySqlExpression,
+                t2.groupBySqlExpression,
+                t3.groupBySqlExpression,
+                t4.groupBySqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
-extension ConcatExpression5: GroupBySQLExpression {
-    public var groupBySqlExpression: some SQLExpression { self }
+extension ConcatExpression5: CompareSQLExpression where
+    T0: CompareSQLExpression,
+    T1: CompareSQLExpression,
+    T2: CompareSQLExpression,
+    T3: CompareSQLExpression,
+    T4: CompareSQLExpression
+{
+    public var compareSqlExpression: some SQLExpression {
+        _Compare(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
+    }
+    
+    private struct _Compare: SQLExpression {
+        let t0: T0
+        let t1: T1
+        let t2: T2
+        let t3: T3
+        let t4: T4
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList([
+                t0.compareSqlExpression,
+                t1.compareSqlExpression,
+                t2.compareSqlExpression,
+                t3.compareSqlExpression,
+                t4.compareSqlExpression
+            ]).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
 }
 
 extension ConcatExpression5 {

--- a/Sources/PSQLKit/Expressions/CountExpression.swift
+++ b/Sources/PSQLKit/Expressions/CountExpression.swift
@@ -9,7 +9,9 @@ public struct CountExpression<Content>: AggregateExpression {
     }
 }
 
-extension CountExpression: SelectSQLExpression where Content: SelectSQLExpression {
+extension CountExpression: SelectSQLExpression where
+    Content: SelectSQLExpression
+{
     public var selectSqlExpression: some SQLExpression {
         _Select(content: content)
     }
@@ -26,7 +28,9 @@ extension CountExpression: SelectSQLExpression where Content: SelectSQLExpressio
     }
 }
 
-extension CountExpression: CompareSQLExpression where Content: CompareSQLExpression {
+extension CountExpression: CompareSQLExpression where
+    Content: CompareSQLExpression
+{
     public var compareSqlExpression: some SQLExpression {
         _Compare(content: content)
     }

--- a/Sources/PSQLKit/Expressions/ExpressionAlias.swift
+++ b/Sources/PSQLKit/Expressions/ExpressionAlias.swift
@@ -10,7 +10,9 @@ extension ExpressionAlias: TypeEquatable where Expression: TypeEquatable {
     public typealias CompareType = Expression.CompareType
 }
 
-extension ExpressionAlias: SelectSQLExpression where Expression: SelectSQLExpression {
+extension ExpressionAlias: SelectSQLExpression where
+    Expression: SelectSQLExpression
+{
     public var selectSqlExpression: some SQLExpression {
         _Select(expression: expression, alias: alias)
     }
@@ -33,7 +35,9 @@ extension ExpressionAlias: SelectSQLExpression where Expression: SelectSQLExpres
     }
 }
 
-extension ExpressionAlias: FromSQLExpression where Expression: FromSQLExpression {
+extension ExpressionAlias: FromSQLExpression where
+    Expression: FromSQLExpression
+{
     public var fromSqlExpression: some SQLExpression {
         _From(expression: expression, alias: alias)
     }

--- a/Sources/PSQLKit/Expressions/MaxExpression.swift
+++ b/Sources/PSQLKit/Expressions/MaxExpression.swift
@@ -9,7 +9,9 @@ public struct MaxExpression<Content>: AggregateExpression {
     }
 }
 
-extension MaxExpression: SelectSQLExpression where Content: SelectSQLExpression {
+extension MaxExpression: SelectSQLExpression where
+    Content: SelectSQLExpression
+{
     public var selectSqlExpression: some SQLExpression {
         _Select(content: content)
     }
@@ -26,7 +28,9 @@ extension MaxExpression: SelectSQLExpression where Content: SelectSQLExpression 
     }
 }
 
-extension MaxExpression: CompareSQLExpression where Content: CompareSQLExpression {
+extension MaxExpression: CompareSQLExpression where
+    Content: CompareSQLExpression
+{
     public var compareSqlExpression: some SQLExpression {
         _Compare(content: content)
     }

--- a/Sources/PSQLKit/Expressions/MinExpression.swift
+++ b/Sources/PSQLKit/Expressions/MinExpression.swift
@@ -9,7 +9,9 @@ public struct MinExpression<Content>: AggregateExpression {
     }
 }
 
-extension MinExpression: SelectSQLExpression where Content: SelectSQLExpression {
+extension MinExpression: SelectSQLExpression where
+    Content: SelectSQLExpression
+{
     public var selectSqlExpression: some SQLExpression {
         _Select(content: content)
     }
@@ -26,7 +28,9 @@ extension MinExpression: SelectSQLExpression where Content: SelectSQLExpression 
     }
 }
 
-extension MinExpression: CompareSQLExpression where Content: CompareSQLExpression {
+extension MinExpression: CompareSQLExpression where
+    Content: CompareSQLExpression
+{
     public var compareSqlExpression: some SQLExpression {
         _Compare(content: content)
     }

--- a/Sources/PSQLKit/Expressions/SumExpression.swift
+++ b/Sources/PSQLKit/Expressions/SumExpression.swift
@@ -9,7 +9,9 @@ public struct SumExpression<Content>: AggregateExpression {
     }
 }
 
-extension SumExpression: SelectSQLExpression where Content: SelectSQLExpression {
+extension SumExpression: SelectSQLExpression where
+    Content: SelectSQLExpression
+{
     public var selectSqlExpression: some SQLExpression {
         _Select(content: content)
     }
@@ -26,7 +28,9 @@ extension SumExpression: SelectSQLExpression where Content: SelectSQLExpression 
     }
 }
 
-extension SumExpression: CompareSQLExpression where Content: CompareSQLExpression {
+extension SumExpression: CompareSQLExpression where
+    Content: CompareSQLExpression
+{
     public var compareSqlExpression: some SQLExpression {
         _Compare(content: content)
     }

--- a/Tests/PSQLKitTests/WhereTests.swift
+++ b/Tests/PSQLKitTests/WhereTests.swift
@@ -251,32 +251,6 @@ final class WhereTests: PSQLTestCase {
         XCTAssertEqual(psqlkitSerializer.sql, compare)
     }
     
-    func testAnyComparison() {
-        let date = DateComponents(calendar: .current, year: 2020, month: 01, day: 01).date!
-        
-        WHERE {
-            AnyCompareExpression(
-                lhs: f.$birthday,
-                operator: .between,
-                rhs: PSQLRange(from: date.psqlDate, to: date.psqlDate)
-            )
-        }
-        .serialize(to: &fluentSerializer)
-        
-        WHERE {
-            AnyCompareExpression(
-                lhs: p.$birthday,
-                operator: .between,
-                rhs: PSQLRange(from: date.psqlDate, to: date.psqlDate)
-            )
-        }
-        .serialize(to: &psqlkitSerializer)
-        
-        let compare = #"WHERE ("x"."birthday" BETWEEN '2020-01-01' AND '2020-01-01')"#
-        XCTAssertEqual(fluentSerializer.sql, compare)
-        XCTAssertEqual(psqlkitSerializer.sql, compare)
-    }
-    
     func testWhereControlFlow() {
         let date = DateComponents(calendar: .current, year: 2020, month: 01, day: 01).date!
         
@@ -293,32 +267,16 @@ final class WhereTests: PSQLTestCase {
             
             switch t1 {
             case .current:
-                AnyCompareExpression(
-                    lhs: f.$birthday,
-                    operator: .between,
-                    rhs: PSQLRange(from: date.psqlDate, to: date.psqlDate)
-                )
+                f.$birthday >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
             case .missing:
-                AnyCompareExpression(
-                    lhs: f.$birthday,
-                    operator: .between,
-                    rhs: PSQLRange(from: date.psqlTimestamp, to: date.psqlTimestamp)
-                )
+                f.$birthday >< PSQLRange(from: date.psqlTimestamp, to: date.psqlTimestamp)
             }
             
             switch t2 {
             case .current:
-                AnyCompareExpression(
-                    lhs: f.$birthday,
-                    operator: .between,
-                    rhs: PSQLRange(from: date.psqlDate, to: date.psqlDate)
-                )
+                f.$birthday >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
             case .missing:
-                AnyCompareExpression(
-                    lhs: f.$birthday,
-                    operator: .between,
-                    rhs: PSQLRange(from: date.psqlTimestamp, to: date.psqlTimestamp)
-                )
+                f.$birthday >< PSQLRange(from: date.psqlTimestamp, to: date.psqlTimestamp)
             }
         }
         .serialize(to: &fluentSerializer)
@@ -328,32 +286,16 @@ final class WhereTests: PSQLTestCase {
             
             switch t1 {
             case .current:
-                AnyCompareExpression(
-                    lhs: p.$birthday,
-                    operator: .between,
-                    rhs: PSQLRange(from: date.psqlDate, to: date.psqlDate)
-                )
+                p.$birthday >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
             case .missing:
-                AnyCompareExpression(
-                    lhs: p.$birthday,
-                    operator: .between,
-                    rhs: PSQLRange(from: date.psqlTimestamp, to: date.psqlTimestamp)
-                )
+                p.$birthday >< PSQLRange(from: date.psqlTimestamp, to: date.psqlTimestamp)
             }
             
             switch t2 {
             case .current:
-                AnyCompareExpression(
-                    lhs: p.$birthday,
-                    operator: .between,
-                    rhs: PSQLRange(from: date.psqlDate, to: date.psqlDate)
-                )
+                p.$birthday >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
             case .missing:
-                AnyCompareExpression(
-                    lhs: p.$birthday,
-                    operator: .between,
-                    rhs: PSQLRange(from: date.psqlTimestamp, to: date.psqlTimestamp)
-                )
+                p.$birthday >< PSQLRange(from: date.psqlTimestamp, to: date.psqlTimestamp)
             }
         }
         .serialize(to: &psqlkitSerializer)


### PR DESCRIPTION
- `COALESCE(3|4|5)` & `CONCAT(3|4|5)` can be compared
- remove `AnyComparison` as control flow works now
- `CONCAT` must now all be same underlying type