### PR TITLE
Concat/Coalesce changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: bug
+assignees: ""
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PSQL query function builders for [FluentKit](https://github.com/vapor/fluent-kit
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/hiimtmac/PSQLKit.git", from: "0.12.0")
+    .package(url: "https://github.com/hiimtmac/PSQLKit.git", from: "0.13.0")
 ],
 ```
 
@@ -430,8 +430,8 @@ The following expressions have been implemented:
 - [x] `COUNT`
 - [x] `SUM`
 - [x] `JSONB_EXTRACT_PATH_TEXT`
-- [x] `COALESCE`/`COALESCE3`/`COALESCE4`/`COALESCE5`
-- [x] `CONCAT`/`CONCAT3`/`CONCAT4`/`CONCAT5`
+- [x] `COALESCE`
+- [x] `CONCAT`
 - [x] `GENERATE_SERIES`
 - [x] `ARRAY_AGG`
 - [x] `ARRAY_APPEND`
@@ -456,7 +456,7 @@ SELECT {
     MAX(m.$craters)
     COUNT(m.$craters).as("crater_count")
     SUM(m.$craters)
-    COALESCE(m.$craters, 5).as("unwrapped_craters")
+    COALESCE<Int.(m.$craters, 5).as("unwrapped_craters")
     CONCAT(m.$name, " is a cool planet").as("annotated")
     GENERATE_SERIES(from: 1, to: 5, interval: 1)
 }

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ SELECT {
     MAX(m.$craters)
     COUNT(m.$craters).as("crater_count")
     SUM(m.$craters)
-    COALESCE<Int.(m.$craters, 5).as("unwrapped_craters")
+    COALESCE<Int>(m.$craters, 5).as("unwrapped_craters")
     CONCAT(m.$name, " is a cool planet").as("annotated")
     GENERATE_SERIES(from: 1, to: 5, interval: 1)
 }

--- a/Sources/PSQLKit/Column/ColumnExpression+Alias.swift
+++ b/Sources/PSQLKit/Column/ColumnExpression+Alias.swift
@@ -1,0 +1,200 @@
+import Foundation
+import SQLKit
+
+extension ColumnExpression {
+    public struct Alias {
+        let column: ColumnExpression<T>
+        let alias: String
+    }
+    
+    public func `as`(_ alias: String) -> ColumnExpression<T>.Alias {
+        Alias(column: self, alias: alias)
+    }
+}
+
+extension ColumnExpression.Alias: TypeEquatable where T: TypeEquatable {
+    public typealias CompareType = T.CompareType
+}
+
+// MARK: Base
+extension ColumnExpression.Alias: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression {
+        _Base(
+            aliasName: column.aliasName,
+            pathName: column.pathName,
+            schemaName: column.schemaName,
+            columnName: column.columnName,
+            columnAlias: alias
+        )
+    }
+    
+    private struct _Base: SQLExpression {
+        let aliasName: String?
+        let pathName: String?
+        let schemaName: String?
+        let columnName: String
+        let columnAlias: String
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            if let alias = aliasName {
+                serializer.writeQuote()
+                serializer.write(alias)
+                serializer.writeQuote()
+                serializer.writePeriod()
+            } else {
+                if let path = pathName {
+                    serializer.writeQuote()
+                    serializer.write(path)
+                    serializer.writeQuote()
+                    serializer.writePeriod()
+                }
+                
+                if let schema = schemaName {
+                    serializer.writeQuote()
+                    serializer.write(schema)
+                    serializer.writeQuote()
+                    serializer.writePeriod()
+                }
+            }
+            
+            serializer.writeQuote()
+            serializer.write(columnName)
+            serializer.writeQuote()
+            
+            serializer.writeSpace()
+            serializer.write("AS")
+            serializer.writeSpace()
+            
+            serializer.writeQuote()
+            serializer.write(columnAlias)
+            serializer.writeQuote()
+        }
+    }
+}
+
+// MARK: Select
+extension ColumnExpression.Alias: SelectSQLExpression {
+    public var selectSqlExpression: some SQLExpression {
+        _Select(
+            aliasName: column.aliasName,
+            pathName: column.pathName,
+            schemaName: column.schemaName,
+            columnName: column.columnName,
+            columnType: T.postgresColumnType,
+            columnAlias: alias
+        )
+    }
+    
+    private struct _Select: SQLExpression {
+        let aliasName: String?
+        let pathName: String?
+        let schemaName: String?
+        let columnName: String
+        let columnType: SQLExpression
+        let columnAlias: String
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            if let alias = aliasName {
+                serializer.writeQuote()
+                serializer.write(alias)
+                serializer.writeQuote()
+                serializer.writePeriod()
+            } else {
+                if let path = pathName {
+                    serializer.writeQuote()
+                    serializer.write(path)
+                    serializer.writeQuote()
+                    serializer.writePeriod()
+                }
+                
+                if let schema = schemaName {
+                    serializer.writeQuote()
+                    serializer.write(schema)
+                    serializer.writeQuote()
+                    serializer.writePeriod()
+                }
+            }
+            
+            serializer.writeQuote()
+            serializer.write(columnName)
+            serializer.writeQuote()
+            
+            serializer.write("::")
+            columnType.serialize(to: &serializer)
+            
+            serializer.writeSpace()
+            serializer.write("AS")
+            serializer.writeSpace()
+            
+            serializer.writeQuote()
+            serializer.write(columnAlias)
+            serializer.writeQuote()
+        }
+    }
+}
+
+extension ColumnExpression.Alias: MutationSQLExpression {
+    public var mutationSqlExpression: some SQLExpression {
+        _Mutation(
+            aliasName: column.aliasName,
+            pathName: column.pathName,
+            schemaName: column.schemaName,
+            columnName: column.columnName,
+            columnType: T.postgresColumnType,
+            columnAlias: alias
+        )
+    }
+    
+    private struct _Mutation: SQLExpression {
+        let aliasName: String?
+        let pathName: String?
+        let schemaName: String?
+        let columnName: String
+        let columnType: SQLExpression
+        let columnAlias: String
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            if let alias = aliasName {
+                serializer.writeQuote()
+                serializer.write(alias)
+                serializer.writeQuote()
+                serializer.writePeriod()
+            } else {
+                if let path = pathName {
+                    serializer.writeQuote()
+                    serializer.write(path)
+                    serializer.writeQuote()
+                    serializer.writePeriod()
+                }
+                
+                if let schema = schemaName {
+                    serializer.writeQuote()
+                    serializer.write(schema)
+                    serializer.writeQuote()
+                    serializer.writePeriod()
+                }
+            }
+            
+            serializer.writeQuote()
+            serializer.write(columnName)
+            serializer.writeQuote()
+            
+            serializer.write("::")
+            columnType.serialize(to: &serializer)
+            
+            serializer.writeSpace()
+            serializer.write("AS")
+            serializer.writeSpace()
+            
+            serializer.writeQuote()
+            serializer.write(columnAlias)
+            serializer.writeQuote()
+        }
+    }
+}
+
+extension ColumnExpression.Alias: Coalescable {}
+
+extension ColumnExpression.Alias: Concatenatable where T: CustomStringConvertible {}
+
+extension ColumnExpression.Alias: JsonbExtractable where T: Codable {}

--- a/Sources/PSQLKit/Column/ColumnProperty.swift
+++ b/Sources/PSQLKit/Column/ColumnProperty.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 @propertyWrapper
-public struct ColumnProperty<Table, Value> {
+public struct ColumnProperty<Table, Value>: Codable where
+    Value: Codable
+{
     let key: String
     
     public init(key: String) {
@@ -16,7 +18,9 @@ public struct ColumnProperty<Table, Value> {
 }
 
 @propertyWrapper
-public struct OptionalColumnProperty<Table, WrappedValue> {
+public struct OptionalColumnProperty<Table, WrappedValue>: Codable where
+    WrappedValue: Codable
+{
     let key: String
     
     public init(key: String) {
@@ -31,7 +35,9 @@ public struct OptionalColumnProperty<Table, WrappedValue> {
 }
 
 @propertyWrapper
-public struct NestedObjectProperty<Table, Nested> {
+public struct NestedObjectProperty<Table, Nested>: Codable where
+    Nested: Codable
+{
     let key: String
 
     public init(key: String) {

--- a/Sources/PSQLKit/Directives.swift
+++ b/Sources/PSQLKit/Directives.swift
@@ -16,6 +16,11 @@ public typealias INSERT = InsertDirective
 public typealias UPDATE = UpdateDirective
 public typealias DELETE = DeleteDirective
 
+public protocol BaseSQLExpression {
+    associatedtype Base: SQLExpression
+    var baseSqlExpression: Base { get }
+}
+
 public protocol SelectSQLExpression {
     associatedtype Select: SQLExpression
     var selectSqlExpression: Select { get }

--- a/Sources/PSQLKit/Expressions.swift
+++ b/Sources/PSQLKit/Expressions.swift
@@ -20,16 +20,8 @@ public typealias ARRAY_REMOVE = ArrayRemoveExpression
 public typealias ARRAY_REPLACE = ArrayReplaceExpression
 public typealias ARRAY_TO_STRING = ArrayToStringExpression
 public typealias ARRAY_UPPER = ArrayUpperExpression
-
 public typealias COALESCE = CoalesceExpression
-public typealias COALESCE3 = CoalesceExpression3
-public typealias COALESCE4 = CoalesceExpression4
-public typealias COALESCE5 = CoalesceExpression5
-
 public typealias CONCAT = ConcatenateExpression
-public typealias CONCAT3 = ConcatenateExpression3
-public typealias CONCAT4 = ConcatenateExpression4
-public typealias CONCAT5 = ConcatenateExpression5
 
 public protocol Expression {}
 public protocol AggregateExpression: Expression {}

--- a/Sources/PSQLKit/Expressions/CoalesceExpression.swift
+++ b/Sources/PSQLKit/Expressions/CoalesceExpression.swift
@@ -1,354 +1,154 @@
 import Foundation
 import SQLKit
+import PostgresKit
+
+public protocol Coalescable: BaseSQLExpression {}
 
 // MARK: CoalesceExpression
-public struct CoalesceExpression<T0, T1> where
-    T0: TypeEquatable,
-    T1: TypeEquatable,
-    T0.CompareType == T1.CompareType
+public struct CoalesceExpression<T> where
+    T: TypeEquatable
 {
-    let t0: T0
-    let t1: T1
+    let values: [SQLExpression]
     
-    public init(_ t0: T0, _ t1: T1) {
-        self.t0 = t0
-        self.t1 = t1
+    public init<T0, T1>(
+        _ t0: T0,
+        _ t1: T1
+    ) where
+        T0: Coalescable & TypeEquatable,
+        T1: Coalescable & TypeEquatable,
+        T.CompareType == T0.CompareType,
+        T0.CompareType == T1.CompareType
+    {
+        self.values = [
+            t0.baseSqlExpression,
+            t1.baseSqlExpression
+        ]
+    }
+    
+    public init<T0, T1, T2>(
+        _ t0: T0,
+        _ t1: T1,
+        _ t2: T2
+    ) where
+        T0: Coalescable & TypeEquatable,
+        T1: Coalescable & TypeEquatable,
+        T2: Coalescable & TypeEquatable,
+        T.CompareType == T0.CompareType,
+        T0.CompareType == T1.CompareType,
+        T1.CompareType == T2.CompareType
+    {
+        self.values = [
+            t0.baseSqlExpression,
+            t1.baseSqlExpression,
+            t2.baseSqlExpression
+        ]
+    }
+    
+    public init<T0, T1, T2, T3>(
+        _ t0: T0,
+        _ t1: T1,
+        _ t2: T2,
+        _ t3: T3
+    ) where
+        T0: Coalescable & TypeEquatable,
+        T1: Coalescable & TypeEquatable,
+        T2: Coalescable & TypeEquatable,
+        T3: Coalescable & TypeEquatable,
+        T.CompareType == T0.CompareType,
+        T0.CompareType == T1.CompareType,
+        T1.CompareType == T2.CompareType,
+        T2.CompareType == T3.CompareType
+    {
+        self.values = [
+            t0.baseSqlExpression,
+            t1.baseSqlExpression,
+            t2.baseSqlExpression,
+            t3.baseSqlExpression
+        ]
+    }
+    
+    public init<T0, T1, T2, T3, T4>(
+        _ t0: T0,
+        _ t1: T1,
+        _ t2: T2,
+        _ t3: T3,
+        _ t4: T4
+    ) where
+        T0: Coalescable & TypeEquatable,
+        T1: Coalescable & TypeEquatable,
+        T2: Coalescable & TypeEquatable,
+        T3: Coalescable & TypeEquatable,
+        T4: Coalescable & TypeEquatable,
+        T.CompareType == T0.CompareType,
+        T0.CompareType == T1.CompareType,
+        T1.CompareType == T2.CompareType,
+        T2.CompareType == T3.CompareType,
+        T3.CompareType == T4.CompareType
+    {
+        self.values = [
+            t0.baseSqlExpression,
+            t1.baseSqlExpression,
+            t2.baseSqlExpression,
+            t3.baseSqlExpression,
+            t4.baseSqlExpression
+        ]
     }
 }
 
 extension CoalesceExpression: TypeEquatable {
-    public typealias CompareType = T0.CompareType
+    public typealias CompareType = T.CompareType
 }
 
-extension CoalesceExpression: SelectSQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression
-{
-    public var selectSqlExpression: some SQLExpression {
-        _Select(t0: t0, t1: t1)
+extension CoalesceExpression: Coalescable {}
+
+extension CoalesceExpression: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression {
+        _Base(values: values)
     }
     
-    private struct _Select: SQLExpression {
-        let t0: T0
-        let t1: T1
+    private struct _Base: SQLExpression {
+        let values: [SQLExpression]
         
         func serialize(to serializer: inout SQLSerializer) {
             serializer.write("COALESCE")
             serializer.write("(")
-            SQLList([
-                t0.selectSqlExpression,
-                t1.selectSqlExpression
-            ]).serialize(to: &serializer)
+            SQLList(values).serialize(to: &serializer)
             serializer.write(")")
+        }
+    }
+}
+
+extension CoalesceExpression: SelectSQLExpression where
+    T: SelectSQLExpression & PSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(values: values)
+    }
+    
+    private struct _Select: SQLExpression {
+        let values: [SQLExpression]
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("COALESCE")
+            serializer.write("(")
+            SQLList(values).serialize(to: &serializer)
+            serializer.write(")")
+            serializer.write("::")
+            T.postgresColumnType.serialize(to: &serializer)
         }
     }
 }
 
 extension CoalesceExpression: CompareSQLExpression where
-    T0: CompareSQLExpression,
-    T1: CompareSQLExpression
+    T: CompareSQLExpression
 {
     public var compareSqlExpression: some SQLExpression {
-        _Compare(t0: t0, t1: t1)
-    }
-    
-    private struct _Compare: SQLExpression {
-        let t0: T0
-        let t1: T1
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("COALESCE")
-            serializer.write("(")
-            SQLList([
-                t0.compareSqlExpression,
-                t1.compareSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
+        _Base(values: values)
     }
 }
 
 extension CoalesceExpression {
-    public func `as`(_ alias: String) -> ExpressionAlias<CoalesceExpression<T0, T1>> {
-        ExpressionAlias(expression: self, alias: alias)
-    }
-}
-
-// MARK: CoalesceExpression3
-public struct CoalesceExpression3<T0, T1, T2> where
-    T0: TypeEquatable,
-    T1: TypeEquatable,
-    T2: TypeEquatable,
-    T0.CompareType == T1.CompareType,
-    T1.CompareType == T2.CompareType
-{
-    let t0: T0
-    let t1: T1
-    let t2: T2
-    
-    public init(_ t0: T0, _ t1: T1, _ t2: T2) {
-        self.t0 = t0
-        self.t1 = t1
-        self.t2 = t2
-    }
-}
-
-extension CoalesceExpression3: TypeEquatable {
-    public typealias CompareType = T0.CompareType
-}
-
-extension CoalesceExpression3: SelectSQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression,
-    T2: SelectSQLExpression
-{
-    public var selectSqlExpression: some SQLExpression {
-        _Select(t0: t0, t1: t1, t2: t2)
-    }
-    
-    private struct _Select: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("COALESCE")
-            serializer.write("(")
-            SQLList([
-                t0.selectSqlExpression,
-                t1.selectSqlExpression,
-                t2.selectSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension CoalesceExpression3: CompareSQLExpression where
-    T0: CompareSQLExpression,
-    T1: CompareSQLExpression,
-    T2: CompareSQLExpression
-{
-    public var compareSqlExpression: some SQLExpression {
-        _Compare(t0: t0, t1: t1, t2: t2)
-    }
-    
-    private struct _Compare: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("COALESCE")
-            serializer.write("(")
-            SQLList([
-                t0.compareSqlExpression,
-                t1.compareSqlExpression,
-                t2.compareSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension CoalesceExpression3 {
-    public func `as`(_ alias: String) -> ExpressionAlias<CoalesceExpression3<T0, T1, T2>> {
-        ExpressionAlias(expression: self, alias: alias)
-    }
-}
-
-// MARK: CoalesceExpression4
-public struct CoalesceExpression4<T0, T1, T2, T3> where
-    T0: TypeEquatable,
-    T1: TypeEquatable,
-    T2: TypeEquatable,
-    T3: TypeEquatable,
-    T0.CompareType == T1.CompareType,
-    T1.CompareType == T2.CompareType,
-    T2.CompareType == T3.CompareType
-{
-    let t0: T0
-    let t1: T1
-    let t2: T2
-    let t3: T3
-    
-    public init(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3) {
-        self.t0 = t0
-        self.t1 = t1
-        self.t2 = t2
-        self.t3 = t3
-    }
-}
-
-extension CoalesceExpression4: TypeEquatable {
-    public typealias CompareType = T0.CompareType
-}
-
-extension CoalesceExpression4: SelectSQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression,
-    T2: SelectSQLExpression,
-    T3: SelectSQLExpression
-{
-    public var selectSqlExpression: some SQLExpression {
-        _Select(t0: t0, t1: t1, t2: t2, t3: t3)
-    }
-    
-    private struct _Select: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("COALESCE")
-            serializer.write("(")
-            SQLList([
-                t0.selectSqlExpression,
-                t1.selectSqlExpression,
-                t2.selectSqlExpression,
-                t3.selectSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension CoalesceExpression4: CompareSQLExpression where
-    T0: CompareSQLExpression,
-    T1: CompareSQLExpression,
-    T2: CompareSQLExpression,
-    T3: CompareSQLExpression
-{
-    public var compareSqlExpression: some SQLExpression {
-        _Compare(t0: t0, t1: t1, t2: t2, t3: t3)
-    }
-    
-    private struct _Compare: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("COALESCE")
-            serializer.write("(")
-            SQLList([
-                t0.compareSqlExpression,
-                t1.compareSqlExpression,
-                t2.compareSqlExpression,
-                t3.compareSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension CoalesceExpression4 {
-    public func `as`(_ alias: String) -> ExpressionAlias<CoalesceExpression4<T0, T1, T2, T3>> {
-        ExpressionAlias(expression: self, alias: alias)
-    }
-}
-
-// MARK: CoalesceExpression5
-public struct CoalesceExpression5<T0, T1, T2, T3, T4> where
-    T0: TypeEquatable,
-    T1: TypeEquatable,
-    T2: TypeEquatable,
-    T3: TypeEquatable,
-    T4: TypeEquatable,
-    T0.CompareType == T1.CompareType,
-    T1.CompareType == T2.CompareType,
-    T2.CompareType == T3.CompareType,
-    T3.CompareType == T4.CompareType
-{
-    let t0: T0
-    let t1: T1
-    let t2: T2
-    let t3: T3
-    let t4: T4
-    
-    public init(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4) {
-        self.t0 = t0
-        self.t1 = t1
-        self.t2 = t2
-        self.t3 = t3
-        self.t4 = t4
-    }
-}
-
-extension CoalesceExpression5: TypeEquatable {
-    public typealias CompareType = T0.CompareType
-}
-
-extension CoalesceExpression5: SelectSQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression,
-    T2: SelectSQLExpression,
-    T3: SelectSQLExpression,
-    T4: SelectSQLExpression
-{
-    public var selectSqlExpression: some SQLExpression {
-        _Select(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
-    }
-    
-    private struct _Select: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        let t4: T4
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("COALESCE")
-            serializer.write("(")
-            SQLList([
-                t0.selectSqlExpression,
-                t1.selectSqlExpression,
-                t2.selectSqlExpression,
-                t3.selectSqlExpression,
-                t4.selectSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension CoalesceExpression5: CompareSQLExpression where
-    T0: CompareSQLExpression,
-    T1: CompareSQLExpression,
-    T2: CompareSQLExpression,
-    T3: CompareSQLExpression,
-    T4: CompareSQLExpression
-{
-    public var compareSqlExpression: some SQLExpression {
-        _Compare(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
-    }
-    
-    private struct _Compare: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        let t4: T4
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("COALESCE")
-            serializer.write("(")
-            SQLList([
-                t0.compareSqlExpression,
-                t1.compareSqlExpression,
-                t2.compareSqlExpression,
-                t3.compareSqlExpression,
-                t4.compareSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension CoalesceExpression5 {
-    public func `as`(_ alias: String) -> ExpressionAlias<CoalesceExpression5<T0, T1, T2, T3, T4>> {
+    public func `as`(_ alias: String) -> ExpressionAlias<CoalesceExpression<T>> {
         ExpressionAlias(expression: self, alias: alias)
     }
 }

--- a/Sources/PSQLKit/Expressions/ConcatenateExpression.swift
+++ b/Sources/PSQLKit/Expressions/ConcatenateExpression.swift
@@ -1,486 +1,149 @@
 import Foundation
 import SQLKit
+import PostgresKit
+
+public protocol Concatenatable: BaseSQLExpression {
+    
+}
 
 // MARK: ConcatenateExpression
-public struct ConcatenateExpression<T0, T1> where
-    T0: TypeEquatable,
-    T1: TypeEquatable,
-    T0.CompareType == T1.CompareType
-{
-    let t0: T0
-    let t1: T1
+public struct ConcatenateExpression {
+    let values: [SQLExpression]
     
-    public init(
+    public init<T0, T1>
+    (
         _ t0: T0,
         _ t1: T1
-    ) {
-        self.t0 = t0
-        self.t1 = t1
+    ) where
+        T0: Concatenatable,
+        T1: Concatenatable
+    {
+        self.values = [
+            t0.baseSqlExpression,
+            t1.baseSqlExpression
+        ]
+    }
+    
+    public init<T0, T1, T2>
+    (
+        _ t0: T0,
+        _ t1: T1,
+        _ t2: T2
+    ) where
+        T0: Concatenatable,
+        T1: Concatenatable,
+        T2: Concatenatable
+    {
+        self.values = [
+            t0.baseSqlExpression,
+            t1.baseSqlExpression,
+            t2.baseSqlExpression
+        ]
+    }
+    
+    public init<T0, T1, T2, T3>
+    (
+        _ t0: T0,
+        _ t1: T1,
+        _ t2: T2,
+        _ t3: T3
+    ) where
+        T0: Concatenatable,
+        T1: Concatenatable,
+        T2: Concatenatable,
+        T3: Concatenatable
+    {
+        self.values = [
+            t0.baseSqlExpression,
+            t1.baseSqlExpression,
+            t2.baseSqlExpression,
+            t3.baseSqlExpression
+        ]
+    }
+    
+    public init<T0, T1, T2, T3, T4>
+    (
+        _ t0: T0,
+        _ t1: T1,
+        _ t2: T2,
+        _ t3: T3,
+        _ t4: T4
+    ) where
+        T0: Concatenatable,
+        T1: Concatenatable,
+        T2: Concatenatable,
+        T3: Concatenatable,
+        T4: Concatenatable
+    {
+        self.values = [
+            t0.baseSqlExpression,
+            t1.baseSqlExpression,
+            t2.baseSqlExpression,
+            t3.baseSqlExpression,
+            t4.baseSqlExpression
+        ]
     }
 }
 
 extension ConcatenateExpression: TypeEquatable {
-    public typealias CompareType = T0.CompareType
+    public typealias CompareType = String
 }
 
-extension ConcatenateExpression: SelectSQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression
-{
+extension ConcatenateExpression: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {
-        _Select(t0: t0, t1: t1)
+        _Select(values: values)
     }
     
     private struct _Select: SQLExpression {
-        let t0: T0
-        let t1: T1
+        let values: [SQLExpression]
         
         func serialize(to serializer: inout SQLSerializer) {
             serializer.write("CONCAT")
             serializer.write("(")
-            SQLList([
-                t0.selectSqlExpression,
-                t1.selectSqlExpression
-            ]).serialize(to: &serializer)
+            SQLList(values).serialize(to: &serializer)
             serializer.write(")")
+            serializer.write("::")
+            PostgresColumnType.text.serialize(to: &serializer)
         }
     }
 }
 
-extension ConcatenateExpression: GroupBySQLExpression where
-    T0: GroupBySQLExpression,
-    T1: GroupBySQLExpression
-{
+extension ConcatenateExpression: GroupBySQLExpression {
     public var groupBySqlExpression: some SQLExpression {
-        _GroupBy(t0: t0, t1: t1)
+        _GroupBy(values: values)
     }
     
     private struct _GroupBy: SQLExpression {
-        let t0: T0
-        let t1: T1
+        let values: [SQLExpression]
         
         func serialize(to serializer: inout SQLSerializer) {
             serializer.write("CONCAT")
             serializer.write("(")
-            SQLList([
-                t0.groupBySqlExpression,
-                t1.groupBySqlExpression
-            ]).serialize(to: &serializer)
+            SQLList(values).serialize(to: &serializer)
             serializer.write(")")
         }
     }
 }
 
-extension ConcatenateExpression: CompareSQLExpression where
-    T0: CompareSQLExpression,
-    T1: CompareSQLExpression
-{
+extension ConcatenateExpression: CompareSQLExpression {
     public var compareSqlExpression: some SQLExpression {
-        _Compare(t0: t0, t1: t1)
+        _Compare(values: values)
     }
     
     private struct _Compare: SQLExpression {
-        let t0: T0
-        let t1: T1
+        let values: [SQLExpression]
         
         func serialize(to serializer: inout SQLSerializer) {
             serializer.write("CONCAT")
             serializer.write("(")
-            SQLList([
-                t0.compareSqlExpression,
-                t1.compareSqlExpression
-            ]).serialize(to: &serializer)
+            SQLList(values).serialize(to: &serializer)
             serializer.write(")")
         }
     }
 }
 
 extension ConcatenateExpression {
-    public func `as`(_ alias: String) -> ExpressionAlias<ConcatenateExpression<T0, T1>> {
-        ExpressionAlias(expression: self, alias: alias)
-    }
-}
-
-// MARK: ConcatenateExpression3
-public struct ConcatenateExpression3<T0, T1, T2> where
-    T0: TypeEquatable,
-    T1: TypeEquatable,
-    T2: TypeEquatable,
-    T0.CompareType == T1.CompareType,
-    T1.CompareType == T2.CompareType
-{
-    let t0: T0
-    let t1: T1
-    let t2: T2
-    
-    public init(
-        _ t0: T0,
-        _ t1: T1,
-        _ t2: T2
-    ) {
-        self.t0 = t0
-        self.t1 = t1
-        self.t2 = t2
-    }
-}
-
-extension ConcatenateExpression3: TypeEquatable {
-    public typealias CompareType = T0.CompareType
-}
-
-extension ConcatenateExpression3: SelectSQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression,
-    T2: SelectSQLExpression
-{
-    public var selectSqlExpression: some SQLExpression {
-        _Select(t0: t0, t1: t1, t2: t2)
-    }
-    
-    private struct _Select: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList([
-                t0.selectSqlExpression,
-                t1.selectSqlExpression,
-                t2.selectSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension ConcatenateExpression3: GroupBySQLExpression where
-    T0: GroupBySQLExpression,
-    T1: GroupBySQLExpression,
-    T2: GroupBySQLExpression
-{
-    public var groupBySqlExpression: some SQLExpression {
-        _GroupBy(t0: t0, t1: t1, t2: t2)
-    }
-    
-    private struct _GroupBy: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList([
-                t0.groupBySqlExpression,
-                t1.groupBySqlExpression,
-                t2.groupBySqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension ConcatenateExpression3: CompareSQLExpression where
-    T0: CompareSQLExpression,
-    T1: CompareSQLExpression,
-    T2: CompareSQLExpression
-{
-    public var compareSqlExpression: some SQLExpression {
-        _Compare(t0: t0, t1: t1, t2: t2)
-    }
-    
-    private struct _Compare: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList([
-                t0.compareSqlExpression,
-                t1.compareSqlExpression,
-                t2.compareSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension ConcatenateExpression3 {
-    public func `as`(_ alias: String) -> ExpressionAlias<ConcatenateExpression3<T0, T1, T2>> {
-        ExpressionAlias(expression: self, alias: alias)
-    }
-}
-
-// MARK: ConcatenateExpression4
-public struct ConcatenateExpression4<T0, T1, T2, T3> where
-    T0: TypeEquatable,
-    T1: TypeEquatable,
-    T2: TypeEquatable,
-    T3: TypeEquatable,
-    T0.CompareType == T1.CompareType,
-    T1.CompareType == T2.CompareType,
-    T2.CompareType == T3.CompareType
-{
-    let t0: T0
-    let t1: T1
-    let t2: T2
-    let t3: T3
-    
-    public init(
-        _ t0: T0,
-        _ t1: T1,
-        _ t2: T2,
-        _ t3: T3
-    ) {
-        self.t0 = t0
-        self.t1 = t1
-        self.t2 = t2
-        self.t3 = t3
-    }
-}
-
-extension ConcatenateExpression4: TypeEquatable {
-    public typealias CompareType = T0.CompareType
-}
-
-extension ConcatenateExpression4: SelectSQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression,
-    T2: SelectSQLExpression,
-    T3: SelectSQLExpression
-{
-    public var selectSqlExpression: some SQLExpression {
-        _Select(t0: t0, t1: t1, t2: t2, t3: t3)
-    }
-    
-    private struct _Select: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList([
-                t0.selectSqlExpression,
-                t1.selectSqlExpression,
-                t2.selectSqlExpression,
-                t3.selectSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension ConcatenateExpression4: GroupBySQLExpression where
-    T0: GroupBySQLExpression,
-    T1: GroupBySQLExpression,
-    T2: GroupBySQLExpression,
-    T3: GroupBySQLExpression
-{
-    public var groupBySqlExpression: some SQLExpression {
-        _GroupBy(t0: t0, t1: t1, t2: t2, t3: t3)
-    }
-    
-    private struct _GroupBy: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList([
-                t0.groupBySqlExpression,
-                t1.groupBySqlExpression,
-                t2.groupBySqlExpression,
-                t3.groupBySqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension ConcatenateExpression4: CompareSQLExpression where
-    T0: CompareSQLExpression,
-    T1: CompareSQLExpression,
-    T2: CompareSQLExpression,
-    T3: CompareSQLExpression
-{
-    public var compareSqlExpression: some SQLExpression {
-        _Compare(t0: t0, t1: t1, t2: t2, t3: t3)
-    }
-    
-    private struct _Compare: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList([
-                t0.compareSqlExpression,
-                t1.compareSqlExpression,
-                t2.compareSqlExpression,
-                t3.compareSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension ConcatenateExpression4 {
-    public func `as`(_ alias: String) -> ExpressionAlias<ConcatenateExpression4<T0, T1, T2, T3>> {
-        ExpressionAlias(expression: self, alias: alias)
-    }
-}
-
-// MARK: ConcatenateExpression5
-public struct ConcatenateExpression5<T0, T1, T2, T3, T4> where
-    T0: TypeEquatable,
-    T1: TypeEquatable,
-    T2: TypeEquatable,
-    T3: TypeEquatable,
-    T4: TypeEquatable,
-    T0.CompareType == T1.CompareType,
-    T1.CompareType == T2.CompareType,
-    T2.CompareType == T3.CompareType,
-    T3.CompareType == T4.CompareType
-{
-    let t0: T0
-    let t1: T1
-    let t2: T2
-    let t3: T3
-    let t4: T4
-    
-    public init(
-        _ t0: T0,
-        _ t1: T1,
-        _ t2: T2,
-        _ t3: T3,
-        _ t4: T4
-    ) {
-        self.t0 = t0
-        self.t1 = t1
-        self.t2 = t2
-        self.t3 = t3
-        self.t4 = t4
-    }
-}
-
-extension ConcatenateExpression5: TypeEquatable {
-    public typealias CompareType = T0.CompareType
-}
-
-extension ConcatenateExpression5: SelectSQLExpression where
-    T0: SelectSQLExpression,
-    T1: SelectSQLExpression,
-    T2: SelectSQLExpression,
-    T3: SelectSQLExpression,
-    T4: SelectSQLExpression
-{
-    public var selectSqlExpression: some SQLExpression {
-        _Select(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
-    }
-    
-    private struct _Select: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        let t4: T4
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList([
-                t0.selectSqlExpression,
-                t1.selectSqlExpression,
-                t2.selectSqlExpression,
-                t3.selectSqlExpression,
-                t4.selectSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension ConcatenateExpression5: GroupBySQLExpression where
-    T0: GroupBySQLExpression,
-    T1: GroupBySQLExpression,
-    T2: GroupBySQLExpression,
-    T3: GroupBySQLExpression,
-    T4: GroupBySQLExpression
-{
-    public var groupBySqlExpression: some SQLExpression {
-        _GroupBy(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
-    }
-    
-    private struct _GroupBy: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        let t4: T4
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList([
-                t0.groupBySqlExpression,
-                t1.groupBySqlExpression,
-                t2.groupBySqlExpression,
-                t3.groupBySqlExpression,
-                t4.groupBySqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension ConcatenateExpression5: CompareSQLExpression where
-    T0: CompareSQLExpression,
-    T1: CompareSQLExpression,
-    T2: CompareSQLExpression,
-    T3: CompareSQLExpression,
-    T4: CompareSQLExpression
-{
-    public var compareSqlExpression: some SQLExpression {
-        _Compare(t0: t0, t1: t1, t2: t2, t3: t3, t4: t4)
-    }
-    
-    private struct _Compare: SQLExpression {
-        let t0: T0
-        let t1: T1
-        let t2: T2
-        let t3: T3
-        let t4: T4
-        
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList([
-                t0.compareSqlExpression,
-                t1.compareSqlExpression,
-                t2.compareSqlExpression,
-                t3.compareSqlExpression,
-                t4.compareSqlExpression
-            ]).serialize(to: &serializer)
-            serializer.write(")")
-        }
-    }
-}
-
-extension ConcatenateExpression5 {
-    public func `as`(_ alias: String) -> ExpressionAlias<ConcatenateExpression5<T0, T1, T2, T3, T4>> {
+    public func `as`(_ alias: String) -> ExpressionAlias<ConcatenateExpression> {
         ExpressionAlias(expression: self, alias: alias)
     }
 }

--- a/Sources/PSQLKit/Expressions/JsonExtractPathText.swift
+++ b/Sources/PSQLKit/Expressions/JsonExtractPathText.swift
@@ -2,28 +2,73 @@ import Foundation
 import SQLKit
 import FluentKit
 
-public struct JsonbExtractPathTextExpression<Content>: SQLExpression where Content: SelectSQLExpression {
-    let content: Content
+public protocol JsonbExtractable: BaseSQLExpression {}
+
+public struct JsonbExtractPathTextExpression<Content> {
+    let content: SQLExpression
     let pathElements: [String]
     
-    public init(_ content: Content, _ paths: String...) {
-        self.content = content
+    public init<T>(_ content: T, _ paths: String..., as: Content.Type) where
+        T: JsonbExtractable
+    {
+        self.content = content.baseSqlExpression
         self.pathElements = paths
-    }
-    
-    public func serialize(to serializer: inout SQLSerializer) {
-        serializer.write("JSONB_EXTRACT_PATH_TEXT")
-        serializer.write("(")
-        content.selectSqlExpression.serialize(to: &serializer)
-        serializer.write(",")
-        serializer.writeSpace()
-        SQLList(pathElements).serialize(to: &serializer)
-        serializer.write(")")
     }
 }
 
-extension JsonbExtractPathTextExpression: SelectSQLExpression {
-    public var selectSqlExpression: some SQLExpression { self }
+extension JsonbExtractPathTextExpression: Coalescable where Content: TypeEquatable {
+
+}
+
+extension JsonbExtractPathTextExpression: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression {
+        _Base(content: content, pathElements: pathElements)
+    }
+    
+    private struct _Base: SQLExpression {
+        let content: SQLExpression
+        let pathElements: [String]
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("JSONB_EXTRACT_PATH_TEXT")
+            serializer.write("(")
+            content.serialize(to: &serializer)
+            serializer.write(",")
+            serializer.writeSpace()
+            SQLList(pathElements).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
+}
+
+extension JsonbExtractPathTextExpression: SelectSQLExpression where
+    Content: PSQLExpression
+{
+    public var selectSqlExpression: some SQLExpression {
+        _Select(
+            content: content,
+            pathElements: pathElements,
+            columnType: Content.postgresColumnType
+        )
+    }
+    
+    private struct _Select: SQLExpression {
+        let content: SQLExpression
+        let pathElements: [String]
+        let columnType: SQLExpression
+        
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("JSONB_EXTRACT_PATH_TEXT")
+            serializer.write("(")
+            content.serialize(to: &serializer)
+            serializer.write(",")
+            serializer.writeSpace()
+            SQLList(pathElements).serialize(to: &serializer)
+            serializer.write(")")
+            serializer.write("::")
+            columnType.serialize(to: &serializer)
+        }
+    }
 }
 
 extension JsonbExtractPathTextExpression {
@@ -32,114 +77,114 @@ extension JsonbExtractPathTextExpression {
     }
 }
 
-extension JsonbExtractPathTextExpression: TypeEquatable {
-    public typealias CompareType = Self
+extension JsonbExtractPathTextExpression: TypeEquatable where Content: TypeEquatable {
+    public typealias CompareType = Content.CompareType
 }
 
 // MARK: Fluent
 extension JsonbExtractPathTextExpression {
-    public init<T, U>(
-        _ group: Content,
-        _ keyPath: KeyPath<T, FieldProperty<T, U>>
-    ) where Content == ColumnExpression<T> {
-        self.content = group
+    public init<T>(
+        _ group: ColumnExpression<T>,
+        _ keyPath: KeyPath<T, FieldProperty<T, Content>>
+    ) {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: keyPath].key.description]
     }
     
-    public init<T, U>(
-        _ group: Content,
-        _ keyPath: KeyPath<T, OptionalFieldProperty<T, U>>
-    ) where Content == ColumnExpression<T> {
-        self.content = group
+    public init<T>(
+        _ group: ColumnExpression<T>,
+        _ keyPath: KeyPath<T, OptionalFieldProperty<T, Content>>
+    ) {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: keyPath].key.description]
     }
     
-    public init<T, U>(
-        _ group: Content,
-        _ keyPath: KeyPath<T, TimestampProperty<T, U>>
-    ) where Content == ColumnExpression<T> {
-        self.content = group
+    public init<T>(
+        _ group: ColumnExpression<T>,
+        _ keyPath: KeyPath<T, TimestampProperty<T, Content>>
+    ) {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: keyPath].$timestamp.key.description]
     }
     
-    public init<T, U>(
-        _ group: Content,
-        _ keyPath: KeyPath<T, IDProperty<T, U>>
-    ) where Content == ColumnExpression<T> {
-        self.content = group
+    public init<T>(
+        _ group: ColumnExpression<T>,
+        _ keyPath: KeyPath<T, IDProperty<T, Content>>
+    ) {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: keyPath].key.description]
     }
     
-    public init<T, U, V>(
-        _ group: Content,
+    public init<T, U>(
+        _ group: ColumnExpression<T>,
         _ first: KeyPath<T, GroupProperty<T, U>>,
-        _ second: KeyPath<U, FieldProperty<U, V>>
-    ) where Content == ColumnExpression<T> {
-        self.content = group
+        _ second: KeyPath<U, FieldProperty<U, Content>>
+    ) {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: first].key.description, U()[keyPath: second].key.description]
     }
     
-    public init<T, U, V>(
-        _ group: Content,
+    public init<T, U>(
+        _ group: ColumnExpression<T>,
         _ first: KeyPath<T, GroupProperty<T, U>>,
-        _ second: KeyPath<U, OptionalFieldProperty<U, V>>
-    ) where Content == ColumnExpression<T> {
-        self.content = group
+        _ second: KeyPath<U, OptionalFieldProperty<U, Content>>
+    ) {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: first].key.description, U()[keyPath: second].key.description]
     }
     
-    public init<T, U, V>(
-        _ group: Content,
+    public init<T, U>(
+        _ group: ColumnExpression<T>,
         _ first: KeyPath<T, GroupProperty<T, U>>,
-        _ second: KeyPath<U, TimestampProperty<U, V>>
-    ) where Content == ColumnExpression<T> {
-        self.content = group
+        _ second: KeyPath<U, TimestampProperty<U, Content>>
+    ) {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: first].key.description, U()[keyPath: second].$timestamp.key.description]
     }
     
-    public init<T, U, V>(
-        _ group: Content,
+    public init<T, U>(
+        _ group: ColumnExpression<T>,
         _ first: KeyPath<T, GroupProperty<T, U>>,
-        _ second: KeyPath<U, IDProperty<U, V>>
-    ) where Content == ColumnExpression<T> {
-        self.content = group
+        _ second: KeyPath<U, IDProperty<U, Content>>
+    ) {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: first].key.description, U()[keyPath: second].key.description]
     }
 }
 
 // MARK: PSQLKit
 extension JsonbExtractPathTextExpression {
-    public init<T, U>(
-        _ group: Content,
-        _ keyPath: KeyPath<T, ColumnProperty<T, U>>
-    ) where Content == ColumnExpression<T>, T: TableObject {
-        self.content = group
+    public init<T>(
+        _ group: ColumnExpression<T>,
+        _ keyPath: KeyPath<T, ColumnProperty<T, Content>>
+    ) where T: TableObject {
+        self.content = group.baseSqlExpression
+        self.pathElements = [T()[keyPath: keyPath].key.description]
+    }
+    
+    public init<T>(
+        _ group: ColumnExpression<T>,
+        _ keyPath: KeyPath<T, OptionalColumnProperty<T, Content>>
+    ) where T: TableObject {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: keyPath].key.description]
     }
     
     public init<T, U>(
-        _ group: Content,
-        _ keyPath: KeyPath<T, OptionalColumnProperty<T, U>>
-    ) where Content == ColumnExpression<T>, T: TableObject {
-        self.content = group
-        self.pathElements = [T()[keyPath: keyPath].key.description]
-    }
-    
-    public init<T, U, V>(
-        _ group: Content,
+        _ group: ColumnExpression<T>,
         _ first: KeyPath<T, NestedObjectProperty<T, U>>,
-        _ second: KeyPath<U, ColumnProperty<U, V>>
-    ) where Content == ColumnExpression<T>, T: TableObject, U: TableObject {
-        self.content = group
+        _ second: KeyPath<U, ColumnProperty<U, Content>>
+    ) where T: TableObject, U: TableObject {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: first].key.description, U()[keyPath: second].key.description]
     }
     
-    public init<T, U, V>(
-        _ group: Content,
+    public init<T, U>(
+        _ group: ColumnExpression<T>,
         _ first: KeyPath<T, NestedObjectProperty<T, U>>,
-        _ second: KeyPath<U, OptionalColumnProperty<U, V>>
-    ) where Content == ColumnExpression<T>, T: TableObject, U: TableObject {
-        self.content = group
+        _ second: KeyPath<U, OptionalColumnProperty<U, Content>>
+    ) where T: TableObject, U: TableObject {
+        self.content = group.baseSqlExpression
         self.pathElements = [T()[keyPath: first].key.description, U()[keyPath: second].key.description]
     }
 }

--- a/Sources/PSQLKit/Primatives/Bool+PSQL.swift
+++ b/Sources/PSQLKit/Primatives/Bool+PSQL.swift
@@ -16,6 +16,13 @@ extension Bool: TypeEquatable {
     public typealias CompareType = Self
 }
 
+extension Bool: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression { self }
+}
+
+extension Bool: Concatenatable {}
+extension Bool: Coalescable {}
+
 extension Bool: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {
         RawValue(self).selectSqlExpression

--- a/Sources/PSQLKit/Primatives/Date+PSQL.swift
+++ b/Sources/PSQLKit/Primatives/Date+PSQL.swift
@@ -16,6 +16,13 @@ extension Date: TypeEquatable {
     public typealias CompareType = Self
 }
 
+extension Date: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression { self }
+}
+
+extension Date: Concatenatable {}
+extension Date: Coalescable {}
+
 extension Date: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {
         RawValue(self).selectSqlExpression
@@ -79,6 +86,13 @@ extension PSQLDate: PSQLExpression {
     public static var postgresColumnType: PostgresColumnType { .date }
 }
 
+extension PSQLDate: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression { self }
+}
+
+extension PSQLDate: Concatenatable {}
+extension PSQLDate: Coalescable {}
+
 extension PSQLDate: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {
         RawValue(self).selectSqlExpression
@@ -103,6 +117,13 @@ public struct PSQLTimestamp: PSQLDateTime {
         return f
     }()
 }
+
+extension PSQLTimestamp: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression { self }
+}
+
+extension PSQLTimestamp: Concatenatable {}
+extension PSQLTimestamp: Coalescable {}
 
 extension PSQLTimestamp: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {

--- a/Sources/PSQLKit/Primatives/Double+PSQL.swift
+++ b/Sources/PSQLKit/Primatives/Double+PSQL.swift
@@ -16,6 +16,13 @@ extension Double: TypeEquatable {
     public typealias CompareType = Self
 }
 
+extension Double: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression { self }
+}
+
+extension Double: Concatenatable {}
+extension Double: Coalescable {}
+
 extension Double: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {
         RawValue(self).selectSqlExpression

--- a/Sources/PSQLKit/Primatives/Float+PSQL.swift
+++ b/Sources/PSQLKit/Primatives/Float+PSQL.swift
@@ -16,6 +16,13 @@ extension Float: TypeEquatable {
     public typealias CompareType = Self
 }
 
+extension Float: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression { self }
+}
+
+extension Float: Concatenatable {}
+extension Float: Coalescable {}
+
 extension Float: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {
         RawValue(self).selectSqlExpression

--- a/Sources/PSQLKit/Primatives/Int+PSQL.swift
+++ b/Sources/PSQLKit/Primatives/Int+PSQL.swift
@@ -16,6 +16,13 @@ extension Int: TypeEquatable {
     public typealias CompareType = Self
 }
 
+extension Int: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression { self }
+}
+
+extension Int: Concatenatable {}
+extension Int: Coalescable {}
+
 extension Int: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {
         RawValue(self).selectSqlExpression

--- a/Sources/PSQLKit/Primatives/String+PSQL.swift
+++ b/Sources/PSQLKit/Primatives/String+PSQL.swift
@@ -18,6 +18,13 @@ extension String: TypeEquatable {
     public typealias CompareType = Self
 }
 
+extension String: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression { self }
+}
+
+extension String: Concatenatable {}
+extension String: Coalescable {}
+
 extension String: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {
         RawValue(self).selectSqlExpression

--- a/Sources/PSQLKit/Primatives/UUID+PSQL.swift
+++ b/Sources/PSQLKit/Primatives/UUID+PSQL.swift
@@ -18,6 +18,13 @@ extension UUID: TypeEquatable {
     public typealias CompareType = Self
 }
 
+extension UUID: BaseSQLExpression {
+    public var baseSqlExpression: some SQLExpression { self }
+}
+
+extension UUID: Concatenatable {}
+extension UUID: Coalescable {}
+
 extension UUID: SelectSQLExpression {
     public var selectSqlExpression: some SQLExpression {
         RawValue(self).selectSqlExpression

--- a/Sources/PSQLKit/Table/Table.swift
+++ b/Sources/PSQLKit/Table/Table.swift
@@ -12,9 +12,9 @@ public protocol Table: FromSQLExpression {
 }
 
 extension Table {
-    public typealias Column<Value> = ColumnProperty<Self, Value>
-    public typealias OptionalColumn<Value> = OptionalColumnProperty<Self, Value>
-    public typealias NestedColumn<Value> = NestedObjectProperty<Self, Value>
+    public typealias Column<Value> = ColumnProperty<Self, Value> where Value: Codable
+    public typealias OptionalColumn<Value> = OptionalColumnProperty<Self, Value> where Value: Codable
+    public typealias NestedColumn<Value> = NestedObjectProperty<Self, Value> where Value: Codable
     
     /// Table Name
     public static var schema: String { "\(Self.self)" }

--- a/Sources/PSQLKit/Table/TableObject.swift
+++ b/Sources/PSQLKit/Table/TableObject.swift
@@ -7,7 +7,7 @@ public protocol TableObject: PSQLExpression {
 
 extension TableObject {
     public static var postgresColumnType: PostgresColumnType { .jsonb }
-    public typealias Column<Value> = ColumnProperty<Self, Value>
-    public typealias OptionalColumn<Value> = OptionalColumnProperty<Self, Value>
-    public typealias NestedColumn<Value> = NestedObjectProperty<Self, Value>
+    public typealias Column<Value> = ColumnProperty<Self, Value> where Value: Codable
+    public typealias OptionalColumn<Value> = OptionalColumnProperty<Self, Value> where Value: Codable
+    public typealias NestedColumn<Value> = NestedObjectProperty<Self, Value> where Value: Codable
 }

--- a/Tests/PSQLKitTests/ExpressionTests.swift
+++ b/Tests/PSQLKitTests/ExpressionTests.swift
@@ -101,71 +101,70 @@ final class ExpressionTests: PSQLTestCase {
     
     func testConcat() {
         SELECT {
-            CONCAT5(f.$name, " ", f.$title, " ", f.$name)
-            CONCAT4(f.$name, " ", f.$title, " ").as("cool")
-            CONCAT3(f.$name, " ", f.$title)
+            CONCAT(f.$name, " ", f.$title, " ", f.$name)
+            CONCAT(f.$name, " ", f.$title, " ").as("cool")
+            CONCAT(f.$name, " ", f.$title)
             CONCAT(8, 8).as("cool")
         }
         .serialize(to: &fluentSerializer)
         
         SELECT {
-            CONCAT5(p.$name, " ", p.$title, " ", p.$name)
-            CONCAT4(p.$name, " ", p.$title, " ").as("cool")
-            CONCAT3(p.$name, " ", p.$title)
+            CONCAT(p.$name, " ", p.$title, " ", p.$name)
+            CONCAT(p.$name, " ", p.$title, " ").as("cool")
+            CONCAT(p.$name, " ", p.$title)
             CONCAT(8, 8).as("cool")
         }
         .serialize(to: &psqlkitSerializer)
         
-        let compare = #"SELECT CONCAT("x"."name"::TEXT, ' '::TEXT, "x"."title"::TEXT, ' '::TEXT, "x"."name"::TEXT), CONCAT("x"."name"::TEXT, ' '::TEXT, "x"."title"::TEXT, ' '::TEXT) AS "cool", CONCAT("x"."name"::TEXT, ' '::TEXT, "x"."title"::TEXT), CONCAT(8::INTEGER, 8::INTEGER) AS "cool""#
+        let compare = #"SELECT CONCAT("x"."name", ' ', "x"."title", ' ', "x"."name")::TEXT, CONCAT("x"."name", ' ', "x"."title", ' ')::TEXT AS "cool", CONCAT("x"."name", ' ', "x"."title")::TEXT, CONCAT(8, 8)::TEXT AS "cool""#
         XCTAssertEqual(fluentSerializer.sql, compare)
         XCTAssertEqual(psqlkitSerializer.sql, compare)
     }
     
     func testCoalesce() {
         SELECT {
-            COALESCE5(f.$name, f.$name, f.$name, f.$name, "hello").as("cool")
-            COALESCE4(f.$name, f.$name, f.$name, "hello").as("cool")
-            COALESCE3(f.$name, f.$name, "hello").as("cool")
-            COALESCE(f.$name, "hello").as("cool")
-            COALESCE(f.$name, COALESCE(f.$name, "hello"))
+            COALESCE<String>(f.$name, f.$name, f.$name, f.$name, "hello").as("cool")
+            COALESCE<String>(f.$name, f.$name, f.$name, "hello").as("cool")
+            COALESCE<String>(f.$name, f.$name, "hello").as("cool")
+            COALESCE<String>(f.$name, "hello").as("cool")
+            COALESCE<String>(f.$name, COALESCE<String>(f.$name, "hello"))
         }
         .serialize(to: &fluentSerializer)
-        
+                
         SELECT {
-            COALESCE5(p.$name, p.$name, p.$name, p.$name, "hello").as("cool")
-            COALESCE4(p.$name, p.$name, p.$name, "hello").as("cool")
-            COALESCE3(p.$name, p.$name, "hello").as("cool")
-            COALESCE(p.$name, "hello").as("cool")
-            COALESCE(p.$name, COALESCE(f.$name, "hello"))
+            COALESCE<String>(p.$name, p.$name, p.$name, p.$name, "hello").as("cool")
+            COALESCE<String>(p.$name, p.$name, p.$name, "hello").as("cool")
+            COALESCE<String>(p.$name, p.$name, "hello").as("cool")
+            COALESCE<String>(p.$name, "hello").as("cool")
+            COALESCE<String>(p.$name, COALESCE<String>(f.$name, "hello"))
         }
         .serialize(to: &psqlkitSerializer)
         
-        let compare = #"SELECT COALESCE("x"."name"::TEXT, "x"."name"::TEXT, "x"."name"::TEXT, "x"."name"::TEXT, 'hello'::TEXT) AS "cool", COALESCE("x"."name"::TEXT, "x"."name"::TEXT, "x"."name"::TEXT, 'hello'::TEXT) AS "cool", COALESCE("x"."name"::TEXT, "x"."name"::TEXT, 'hello'::TEXT) AS "cool", COALESCE("x"."name"::TEXT, 'hello'::TEXT) AS "cool", COALESCE("x"."name"::TEXT, COALESCE("x"."name"::TEXT, 'hello'::TEXT))"#
+        let compare = #"SELECT COALESCE("x"."name", "x"."name", "x"."name", "x"."name", 'hello')::TEXT AS "cool", COALESCE("x"."name", "x"."name", "x"."name", 'hello')::TEXT AS "cool", COALESCE("x"."name", "x"."name", 'hello')::TEXT AS "cool", COALESCE("x"."name", 'hello')::TEXT AS "cool", COALESCE("x"."name", COALESCE("x"."name", 'hello'))::TEXT"#
         XCTAssertEqual(fluentSerializer.sql, compare)
         XCTAssertEqual(psqlkitSerializer.sql, compare)
     }
     
     func testJsonExtractPathText() {
         SELECT {
-            JSONB_EXTRACT_PATH_TEXT(f.$pet, "hello").as("cool")
-            JSONB_EXTRACT_PATH_TEXT(f.$pet, "hello", "cool")
+            JSONB_EXTRACT_PATH_TEXT(f.$pet, "hello", as: String.self).as("cool")
+            JSONB_EXTRACT_PATH_TEXT(f.$pet, "hello", "cool", as: String.self)
         }
         .serialize(to: &fluentSerializer)
-        
         SELECT {
-            JSONB_EXTRACT_PATH_TEXT(p.$pet, "hello").as("cool")
-            JSONB_EXTRACT_PATH_TEXT(p.$pet, "hello", "cool")
+            JSONB_EXTRACT_PATH_TEXT(p.$pet, "hello", as: String.self).as("cool")
+            JSONB_EXTRACT_PATH_TEXT(p.$pet, "hello", "cool", as: String.self)
         }
         .serialize(to: &psqlkitSerializer)
         
-        let compare = #"SELECT JSONB_EXTRACT_PATH_TEXT("x"."pet"::JSONB, 'hello') AS "cool", JSONB_EXTRACT_PATH_TEXT("x"."pet"::JSONB, 'hello', 'cool')"#
+        let compare = #"SELECT JSONB_EXTRACT_PATH_TEXT("x"."pet", 'hello')::TEXT AS "cool", JSONB_EXTRACT_PATH_TEXT("x"."pet", 'hello', 'cool')::TEXT"#
         XCTAssertEqual(fluentSerializer.sql, compare)
         XCTAssertEqual(psqlkitSerializer.sql, compare)
     }
     
     func testNestedJsonExtract() {
         SELECT {
-            COALESCE(
+            COALESCE<String>(
                 JSONB_EXTRACT_PATH_TEXT(f.$pet, \.$name),
                 JSONB_EXTRACT_PATH_TEXT(f.$pet, \.$type)
             )
@@ -173,14 +172,14 @@ final class ExpressionTests: PSQLTestCase {
         .serialize(to: &fluentSerializer)
         
         SELECT {
-            COALESCE(
+            COALESCE<String>(
                 JSONB_EXTRACT_PATH_TEXT(p.$pet, \.$name),
                 JSONB_EXTRACT_PATH_TEXT(p.$pet, \.$type)
             )
         }
         .serialize(to: &psqlkitSerializer)
         
-        let compare = #"SELECT COALESCE(JSONB_EXTRACT_PATH_TEXT("x"."pet"::JSONB, 'name'), JSONB_EXTRACT_PATH_TEXT("x"."pet"::JSONB, 'type'))"#
+        let compare = #"SELECT COALESCE(JSONB_EXTRACT_PATH_TEXT("x"."pet", 'name'), JSONB_EXTRACT_PATH_TEXT("x"."pet", 'type'))::TEXT"#
         XCTAssertEqual(fluentSerializer.sql, compare)
         XCTAssertEqual(psqlkitSerializer.sql, compare)
     }
@@ -189,14 +188,14 @@ final class ExpressionTests: PSQLTestCase {
         let date = DateComponents(calendar: .current, year: 2021, month: 01, day: 21).date!
         
         WHERE {
-            COALESCE(f.$name, "tmac") == "taylor"
-            COALESCE(f.$birthday, date.psqlDate) >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
+            COALESCE<String>(f.$name, "tmac") == "taylor"
+            COALESCE<PSQLDate>(f.$birthday, date.psqlDate) >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
         }
         .serialize(to: &fluentSerializer)
         
         WHERE {
-            COALESCE(p.$name, "tmac") == "taylor"
-            COALESCE(p.$birthday, date.psqlDate) >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
+            COALESCE<String>(p.$name, "tmac") == "taylor"
+            COALESCE<PSQLDate>(p.$birthday, date.psqlDate) >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
         }
         .serialize(to: &psqlkitSerializer)
         

--- a/Tests/PSQLKitTests/NestedTests.swift
+++ b/Tests/PSQLKitTests/NestedTests.swift
@@ -19,7 +19,7 @@ final class NestedTests: PSQLTestCase {
         }
         .serialize(to: &psqlkitSerializer)
         
-        let compare = #"SELECT JSONB_EXTRACT_PATH_TEXT("x"."pet"::JSONB, 'name'), JSONB_EXTRACT_PATH_TEXT("x"."pet"::JSONB, 'info', 'name')"#
+        let compare = #"SELECT JSONB_EXTRACT_PATH_TEXT("x"."pet", 'name')::TEXT, JSONB_EXTRACT_PATH_TEXT("x"."pet", 'info', 'name')::TEXT"#
         XCTAssertEqual(fluentSerializer.sql, compare)
         XCTAssertEqual(psqlkitSerializer.sql, compare)
     }

--- a/Tests/PSQLKitTests/PSQLTests.swift
+++ b/Tests/PSQLKitTests/PSQLTests.swift
@@ -45,14 +45,14 @@ struct PSQLModel: Table {
     
     init() {}
     
-    struct Pet: TableObject {
+    struct Pet: TableObject, Codable {
         @Column(key: "name") var name: String
         @Column(key: "type") var type: String
         @NestedColumn(key: "info") var info: Info
 
         init() { }
         
-        struct Info: TableObject {
+        struct Info: TableObject, Codable {
             @Column(key: "name") var name: String
 
             init() { }

--- a/Tests/PSQLKitTests/ReadmeTests.swift
+++ b/Tests/PSQLKitTests/ReadmeTests.swift
@@ -243,7 +243,7 @@ SELECT {
     MAX(m.$craters)
     COUNT(m.$craters).as("crater_count")
     SUM(m.$craters)
-    COALESCE(m.$craters, 5).as("unwrapped_craters")
+    COALESCE<Int>(m.$craters, 5).as("unwrapped_craters")
     CONCAT(m.$name, " is a cool planet").as("annotated")
     GENERATE_SERIES(from: 1, to: 5, interval: 1)
 }


### PR DESCRIPTION
Replace `COALESCE(3|4|5)` and `CONCAT(3|4|5)` single item. 

Reasoning: It doesn't need to hold all the types that make it up, only the final type is needed (for compare etc)

`COALESCE` needs the type specified: ex `COALESCE<Int>` or `COALESCE<String>` because implied generics was giving me a hard time. Probably a way to get it to be coerced but couldn't figure it out for now.