### PR TITLE
remove typing need for coalesce

### DIFF
--- a/Sources/PSQLKit/Expressions/CoalesceExpression.swift
+++ b/Sources/PSQLKit/Expressions/CoalesceExpression.swift
@@ -2,7 +2,6 @@
 // Copyright © 2022 hiimtmac
 
 import Foundation
-import PostgresKit
 import SQLKit
 
 public protocol Coalescable: BaseSQLExpression {}
@@ -20,7 +19,7 @@ public struct CoalesceExpression<T> where
     ) where
         T0: Coalescable & TypeEquatable,
         T1: Coalescable & TypeEquatable,
-        T.CompareType == T0.CompareType,
+        T == T0.CompareType,
         T0.CompareType == T1.CompareType
     {
         self.values = [
@@ -37,7 +36,7 @@ public struct CoalesceExpression<T> where
         T0: Coalescable & TypeEquatable,
         T1: Coalescable & TypeEquatable,
         T2: Coalescable & TypeEquatable,
-        T.CompareType == T0.CompareType,
+        T == T0.CompareType,
         T0.CompareType == T1.CompareType,
         T1.CompareType == T2.CompareType
     {
@@ -58,7 +57,7 @@ public struct CoalesceExpression<T> where
         T1: Coalescable & TypeEquatable,
         T2: Coalescable & TypeEquatable,
         T3: Coalescable & TypeEquatable,
-        T.CompareType == T0.CompareType,
+        T == T0.CompareType,
         T0.CompareType == T1.CompareType,
         T1.CompareType == T2.CompareType,
         T2.CompareType == T3.CompareType
@@ -83,7 +82,7 @@ public struct CoalesceExpression<T> where
         T2: Coalescable & TypeEquatable,
         T3: Coalescable & TypeEquatable,
         T4: Coalescable & TypeEquatable,
-        T.CompareType == T0.CompareType,
+        T == T0.CompareType,
         T0.CompareType == T1.CompareType,
         T1.CompareType == T2.CompareType,
         T2.CompareType == T3.CompareType,

--- a/Sources/PSQLKit/Expressions/ConcatenateExpression.swift
+++ b/Sources/PSQLKit/Expressions/ConcatenateExpression.swift
@@ -91,6 +91,23 @@ extension ConcatenateExpression: TypeEquatable {
     public typealias CompareType = String
 }
 
+extension ConcatenateExpression: BaseSQLExpression {
+    public var baseSqlExpression: SQLExpression {
+        _Base(values: self.values)
+    }
+
+    private struct _Base: SQLExpression {
+        let values: [SQLExpression]
+
+        func serialize(to serializer: inout SQLSerializer) {
+            serializer.write("CONCAT")
+            serializer.write("(")
+            SQLList(self.values).serialize(to: &serializer)
+            serializer.write(")")
+        }
+    }
+}
+
 extension ConcatenateExpression: SelectSQLExpression {
     public var selectSqlExpression: SQLExpression {
         _Select(values: self.values)
@@ -112,35 +129,13 @@ extension ConcatenateExpression: SelectSQLExpression {
 
 extension ConcatenateExpression: GroupBySQLExpression {
     public var groupBySqlExpression: SQLExpression {
-        _GroupBy(values: self.values)
-    }
-
-    private struct _GroupBy: SQLExpression {
-        let values: [SQLExpression]
-
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList(self.values).serialize(to: &serializer)
-            serializer.write(")")
-        }
+        _Base(values: self.values)
     }
 }
 
 extension ConcatenateExpression: CompareSQLExpression {
     public var compareSqlExpression: SQLExpression {
-        _Compare(values: self.values)
-    }
-
-    private struct _Compare: SQLExpression {
-        let values: [SQLExpression]
-
-        func serialize(to serializer: inout SQLSerializer) {
-            serializer.write("CONCAT")
-            serializer.write("(")
-            SQLList(self.values).serialize(to: &serializer)
-            serializer.write(")")
-        }
+        _Base(values: self.values)
     }
 }
 

--- a/Tests/PSQLKitTests/ExpressionTests.swift
+++ b/Tests/PSQLKitTests/ExpressionTests.swift
@@ -150,20 +150,20 @@ final class ExpressionTests: PSQLTestCase {
 
     func testCoalesce() {
         SELECT {
-            COALESCE<String>(f.$name, f.$name, f.$name, f.$name, "hello").as("cool")
-            COALESCE<String>(f.$name, f.$name, f.$name, "hello").as("cool")
-            COALESCE<String>(f.$name, f.$name, "hello").as("cool")
-            COALESCE<String>(f.$name, "hello").as("cool")
-            COALESCE<String>(f.$name, COALESCE<String>(f.$name, "hello"))
+            COALESCE(f.$name, f.$name, f.$name, f.$name, "hello").as("cool")
+            COALESCE(f.$name, f.$name, f.$name, "hello").as("cool")
+            COALESCE(f.$name, f.$name, "hello").as("cool")
+            COALESCE(f.$name, "hello").as("cool")
+            COALESCE(f.$name, COALESCE(f.$name, "hello"))
         }
         .serialize(to: &fluentSerializer)
 
         SELECT {
-            COALESCE<String>(p.$name, p.$name, p.$name, p.$name, "hello").as("cool")
-            COALESCE<String>(p.$name, p.$name, p.$name, "hello").as("cool")
-            COALESCE<String>(p.$name, p.$name, "hello").as("cool")
-            COALESCE<String>(p.$name, "hello").as("cool")
-            COALESCE<String>(p.$name, COALESCE<String>(f.$name, "hello"))
+            COALESCE(p.$name, p.$name, p.$name, p.$name, "hello").as("cool")
+            COALESCE(p.$name, p.$name, p.$name, "hello").as("cool")
+            COALESCE(p.$name, p.$name, "hello").as("cool")
+            COALESCE(p.$name, "hello").as("cool")
+            COALESCE(p.$name, COALESCE(f.$name, "hello"))
         }
         .serialize(to: &psqlkitSerializer)
 
@@ -191,7 +191,7 @@ final class ExpressionTests: PSQLTestCase {
 
     func testNestedJsonExtract() {
         SELECT {
-            COALESCE<String>(
+            COALESCE(
                 JSONB_EXTRACT_PATH_TEXT(f.$pet, \.$name),
                 JSONB_EXTRACT_PATH_TEXT(f.$pet, \.$type)
             )
@@ -199,7 +199,7 @@ final class ExpressionTests: PSQLTestCase {
         .serialize(to: &fluentSerializer)
 
         SELECT {
-            COALESCE<String>(
+            COALESCE(
                 JSONB_EXTRACT_PATH_TEXT(p.$pet, \.$name),
                 JSONB_EXTRACT_PATH_TEXT(p.$pet, \.$type)
             )
@@ -215,14 +215,14 @@ final class ExpressionTests: PSQLTestCase {
         let date = DateComponents(calendar: .current, year: 2021, month: 01, day: 21).date!
 
         WHERE {
-            COALESCE<String>(f.$name, "tmac") == "taylor"
-            COALESCE<PSQLDate>(f.$birthday, date.psqlDate) >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
+            COALESCE(f.$name, "tmac") == "taylor"
+            COALESCE(f.$birthday, date.psqlDate) >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
         }
         .serialize(to: &fluentSerializer)
 
         WHERE {
-            COALESCE<String>(p.$name, "tmac") == "taylor"
-            COALESCE<PSQLDate>(p.$birthday, date.psqlDate) >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
+            COALESCE(p.$name, "tmac") == "taylor"
+            COALESCE(p.$birthday, date.psqlDate) >< PSQLRange(from: date.psqlDate, to: date.psqlDate)
         }
         .serialize(to: &psqlkitSerializer)
 
@@ -577,12 +577,12 @@ final class ExpressionTests: PSQLTestCase {
 
     func testConcateWithCoalesce() {
         SELECT {
-            CONCAT(COALESCE<String>(f.$name, "hi"), " there")
+            CONCAT(COALESCE(f.$name, "hi"), " there")
         }
         .serialize(to: &fluentSerializer)
 
         SELECT {
-            CONCAT(COALESCE<String>(p.$name, "hi"), " there")
+            CONCAT(COALESCE(p.$name, "hi"), " there")
         }
         .serialize(to: &psqlkitSerializer)
 

--- a/Tests/PSQLKitTests/ReadmeTests.swift
+++ b/Tests/PSQLKitTests/ReadmeTests.swift
@@ -245,7 +245,7 @@ final class ReadmeTests: PSQLTestCase {
             MAX(m.$craters)
             COUNT(m.$craters).as("crater_count")
             SUM(m.$craters)
-            COALESCE<Int>(m.$craters, 5).as("unwrapped_craters")
+            COALESCE(m.$craters, 5).as("unwrapped_craters")
             CONCAT(m.$name, " is a cool planet").as("annotated")
             GENERATE_SERIES(from: 1, to: 5, interval: 1)
         }


### PR DESCRIPTION
No longer need `COALESCE<String>(...)` the type is inferred by the first argument's `CompareType`